### PR TITLE
Update DG delete

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -474,7 +474,18 @@ testers are expected to do more *exploratory* testing.
    1. Other incorrect delete commands to try: `delete`, `delete x`, `...` (where x is larger than the list size)<br>
       Expected: Similar to previous.
 
-1. _{ more test cases …​ }_
+1. Deleting a person while found persons are being shown
+
+    1. Prerequisites: Find people with names matching a particular keyword using the `find` command. 
+
+    1. Test case: `delete x`<br> (where x is less than or equal to the number of found persons)
+       Expected: Contact x is deleted from the list. Details of the deleted contact shown in the status message. Timestamp in the status bar is updated.
+
+    1. Test case: `delete 0`<br>
+       Expected: No person is deleted. Error details shown in the status message. Status bar remains the same.
+
+    1. Other incorrect delete commands to try: `delete`, `delete x`, `...` (where x is larger than the list size)<br>
+       Expected: Similar to previous.
 
 ### Saving data
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -474,7 +474,7 @@ testers are expected to do more *exploratory* testing.
    1. Other incorrect delete commands to try: `delete`, `delete x`, `...` (where x is larger than the list size)<br>
       Expected: Similar to previous.
 
-1. Deleting a person while found persons are being shown
+2. Deleting a person while found persons are being shown
 
     1. Prerequisites: Find people with names matching a particular keyword using the `find` command. 
 


### PR DESCRIPTION
Closes #54

Closes #53 
Delete in AB3 already matches our MVP specification. The specification had different error messages as compared to those currently being used. However, the AB3 messages are better than those in the MVP specification, so it is best to keep them. 

Closes #55 
Since there were no changes made to delete there is no need to create or modify any associated test cases. 