### PR TITLE
Enable finding by specific fields

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -56,7 +56,9 @@ public class FindCommand extends Command {
         this.phonePredicate = phonePredicate;
         this.addressPredicate = addressPredicate;
 
-        Predicate<Person> basePredicate = namePredicate == null && phonePredicate == null && addressPredicate == null
+        Predicate<Person> basePredicate = ((namePredicate == null)
+                && (phonePredicate == null)
+                && (addressPredicate == null))
                 ? person -> false : person -> true;
 
         if (namePredicate != null) {
@@ -92,7 +94,6 @@ public class FindCommand extends Command {
         }
 
         FindCommand otherFindCommand = (FindCommand) other;
-
 
         return (Objects.equals(this.namePredicate, otherFindCommand.namePredicate))
                 && (Objects.equals(this.phonePredicate, otherFindCommand.phonePredicate))

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -35,6 +35,16 @@ public class FindCommand extends Command {
 
     private final Predicate<Person> combinedPredicate;
 
+    /**
+     * Constructs a FindCommand object with optional predicates for filtering by name, phone, and address.
+     * The command updates the filtered person list based on which predicates are present.
+     * @param namePredicate  The predicate used to filter persons by their name,
+     *                       or null if no name filtering is required.
+     * @param phonePredicate  The predicate used to filter persons by their phone,
+     *                        or null if no phone filtering is required.
+     * @param addressPredicate  The predicate used to filter persons by their address,
+     *                          or null if no address filtering is required.
+     */
     public FindCommand(NameContainsKeywordsPredicate namePredicate,
                        PhoneContainsKeywordsPredicate phonePredicate,
                        AddressContainsKeywordsPredicate addressPredicate) {

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -106,8 +106,5 @@ public class FindCommand extends Command {
                 .add("phonePredicate", phonePredicate == null ? "null" : phonePredicate.toString())
                 .add("addressPredicate", addressPredicate == null ? "null" : addressPredicate.toString())
                 .toString();
-//        return new ToStringBuilder(this)
-//                .add("combinedPredicate", combinedPredicate)
-//                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
+import java.util.Objects;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.ToStringBuilder;
@@ -34,6 +35,9 @@ public class FindCommand extends Command {
             + COMMAND_WORD + " " + PREFIX_PHONE + "9243 9312";
 
     private final Predicate<Person> combinedPredicate;
+    private final NameContainsKeywordsPredicate namePredicate;
+    private final PhoneContainsKeywordsPredicate phonePredicate;
+    private final AddressContainsKeywordsPredicate addressPredicate;
 
     /**
      * Constructs a FindCommand object with optional predicates for filtering by name, phone, and address.
@@ -48,7 +52,12 @@ public class FindCommand extends Command {
     public FindCommand(NameContainsKeywordsPredicate namePredicate,
                        PhoneContainsKeywordsPredicate phonePredicate,
                        AddressContainsKeywordsPredicate addressPredicate) {
-        Predicate<Person> basePredicate = person -> true;
+        this.namePredicate = namePredicate;
+        this.phonePredicate = phonePredicate;
+        this.addressPredicate = addressPredicate;
+
+        Predicate<Person> basePredicate = namePredicate == null && phonePredicate == null && addressPredicate == null
+                ? person -> false : person -> true;
 
         if (namePredicate != null) {
             basePredicate = basePredicate.and(namePredicate);
@@ -83,13 +92,22 @@ public class FindCommand extends Command {
         }
 
         FindCommand otherFindCommand = (FindCommand) other;
-        return combinedPredicate.equals(otherFindCommand.combinedPredicate);
+
+
+        return (Objects.equals(this.namePredicate, otherFindCommand.namePredicate))
+                && (Objects.equals(this.phonePredicate, otherFindCommand.phonePredicate))
+                && (Objects.equals(this.addressPredicate, otherFindCommand.addressPredicate));
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("combinedPredicate", combinedPredicate)
+                .add("namePredicate", namePredicate == null ? "null" : namePredicate.toString())
+                .add("phonePredicate", phonePredicate == null ? "null" : phonePredicate.toString())
+                .add("addressPredicate", addressPredicate == null ? "null" : addressPredicate.toString())
                 .toString();
+//        return new ToStringBuilder(this)
+//                .add("combinedPredicate", combinedPredicate)
+//                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -74,6 +74,33 @@ public class FindCommand extends Command {
         this.combinedPredicate = basePredicate;
     }
 
+    public FindCommand(NameContainsKeywordsPredicate namePredicate,
+                       PhoneContainsKeywordsPredicate phonePredicate) {
+        this(namePredicate, phonePredicate, null);
+    }
+
+    public FindCommand(PhoneContainsKeywordsPredicate phonePredicate,
+                       AddressContainsKeywordsPredicate addressPredicate) {
+        this(null, phonePredicate, addressPredicate);
+    }
+
+    public FindCommand(NameContainsKeywordsPredicate namePredicate,
+                       AddressContainsKeywordsPredicate addressPredicate) {
+        this(namePredicate, null, addressPredicate);
+    }
+
+    public FindCommand(NameContainsKeywordsPredicate namePredicate) {
+        this(namePredicate, null, null);
+    }
+
+    public FindCommand(PhoneContainsKeywordsPredicate phonePredicate) {
+        this(null, phonePredicate, null);
+    }
+
+    public FindCommand(AddressContainsKeywordsPredicate addressPredicate) {
+        this(null, null, addressPredicate);
+    }
+
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -75,4 +75,14 @@ public class ArgumentMultimap {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(duplicatedPrefixes));
         }
     }
+
+    /**
+     * Checks if prefix is present, used specifically for find command
+     * where not all prefixes have to be present.
+     * @param prefix Prefix of argument
+     * @return true if prefix is present in argMultimap, false otherwise
+     */
+    public boolean isPresent(Prefix prefix) {
+        return argMultimap.containsKey(prefix);
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -46,9 +46,12 @@ public class FindCommandParser implements Parser<FindCommand> {
         System.out.println(Arrays.toString(addressKeywords));
 
         // Create the specific predicates, or pass null if no valid keywords were provided
-        NameContainsKeywordsPredicate namePredicate = nameKeywords != null ? new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)) : null;
-        PhoneContainsKeywordsPredicate phonePredicate = phoneKeywords != null ? new PhoneContainsKeywordsPredicate(Arrays.asList(phoneKeywords)) : null;
-        AddressContainsKeywordsPredicate addressPredicate = addressKeywords != null ? new AddressContainsKeywordsPredicate(Arrays.asList(addressKeywords)) : null;
+        NameContainsKeywordsPredicate namePredicate = nameKeywords != null
+                ? new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)) : null;
+        PhoneContainsKeywordsPredicate phonePredicate = phoneKeywords != null
+                ? new PhoneContainsKeywordsPredicate(Arrays.asList(phoneKeywords)) : null;
+        AddressContainsKeywordsPredicate addressPredicate = addressKeywords != null
+                ? new AddressContainsKeywordsPredicate(Arrays.asList(addressKeywords)) : null;
 
         return new FindCommand(namePredicate, phonePredicate, addressPredicate);
     }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -27,7 +27,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_ADDRESS);
 
-        if (!argMultimap.getPreamble().isEmpty()) {
+        if (!argMultimap.getPreamble().isEmpty() || args.trim().isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
@@ -43,7 +43,6 @@ public class FindCommandParser implements Parser<FindCommand> {
         String[] addressKeywords = argMultimap.isPresent(PREFIX_ADDRESS)
                 ? argMultimap.getValue(PREFIX_ADDRESS).get().trim().split("_")
                 : null;
-        System.out.println(Arrays.toString(addressKeywords));
 
         // Create the specific predicates, or pass null if no valid keywords were provided
         NameContainsKeywordsPredicate namePredicate = nameKeywords != null

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,17 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import java.util.Arrays;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -19,15 +24,33 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_ADDRESS);
+
+        if (!argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_ADDRESS);
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        String[] nameKeywords = argMultimap.isPresent(PREFIX_NAME)
+                ? argMultimap.getValue(PREFIX_NAME).get().trim().split("\\s+")
+                : null;
+        String[] phoneKeywords = argMultimap.isPresent(PREFIX_PHONE)
+                ? argMultimap.getValue(PREFIX_PHONE).get().trim().split("\\s+")
+                : null;
+        String[] addressKeywords = argMultimap.isPresent(PREFIX_ADDRESS)
+                ? argMultimap.getValue(PREFIX_ADDRESS).get().trim().split("_")
+                : null;
+        System.out.println(Arrays.toString(addressKeywords));
+
+        // Create the specific predicates, or pass null if no valid keywords were provided
+        NameContainsKeywordsPredicate namePredicate = nameKeywords != null ? new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)) : null;
+        PhoneContainsKeywordsPredicate phonePredicate = phoneKeywords != null ? new PhoneContainsKeywordsPredicate(Arrays.asList(phoneKeywords)) : null;
+        AddressContainsKeywordsPredicate addressPredicate = addressKeywords != null ? new AddressContainsKeywordsPredicate(Arrays.asList(addressKeywords)) : null;
+
+        return new FindCommand(namePredicate, phonePredicate, addressPredicate);
     }
 
 }

--- a/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
@@ -24,18 +24,13 @@ public class AddressContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean equals(Object other) {
-        System.out.println("This is in equals of AddressContainsPredicate class!");
-        System.out.println(other);
-
         if (other == this) {
             return true;
         }
 
         // instanceof handles nulls
-        if (!(other instanceof AddressContainsKeywordsPredicate)) {
-            if (other != null) {
-                return false;
-            }
+        if (!(other instanceof AddressContainsKeywordsPredicate) && other != null) {
+            return false;
         }
 
         AddressContainsKeywordsPredicate otherAddressContainsKeywordsPredicate =

--- a/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
@@ -24,18 +24,24 @@ public class AddressContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean equals(Object other) {
+        System.out.println("This is in equals of AddressContainsPredicate class!");
+        System.out.println(other);
+
         if (other == this) {
             return true;
         }
 
         // instanceof handles nulls
-        if (!(other instanceof NameContainsKeywordsPredicate)) {
-            return false;
+        if (!(other instanceof AddressContainsKeywordsPredicate)) {
+            if (other != null) {
+                return false;
+            }
         }
 
         AddressContainsKeywordsPredicate otherAddressContainsKeywordsPredicate =
                 (AddressContainsKeywordsPredicate) other;
-        return keywords.equals(otherAddressContainsKeywordsPredicate.keywords);
+        return keywords.equals(otherAddressContainsKeywordsPredicate != null
+                ? otherAddressContainsKeywordsPredicate.keywords : null);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
@@ -1,0 +1,45 @@
+package seedu.address.model.person;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s {@code Phone} matches any of the keywords given.
+ */
+public class AddressContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public AddressContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        // Checks if the string i.e (address) contains a keyword, allowing partial matching of address via find command
+        return keywords.stream()
+                .anyMatch(keyword -> person.getAddress().value.toLowerCase().contains(keyword.toLowerCase()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof NameContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        AddressContainsKeywordsPredicate otherAddressContainsKeywordsPredicate = (AddressContainsKeywordsPredicate) other;
+        return keywords.equals(otherAddressContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
@@ -1,6 +1,5 @@
 package seedu.address.model.person;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -34,7 +33,8 @@ public class AddressContainsKeywordsPredicate implements Predicate<Person> {
             return false;
         }
 
-        AddressContainsKeywordsPredicate otherAddressContainsKeywordsPredicate = (AddressContainsKeywordsPredicate) other;
+        AddressContainsKeywordsPredicate otherAddressContainsKeywordsPredicate =
+                (AddressContainsKeywordsPredicate) other;
         return keywords.equals(otherAddressContainsKeywordsPredicate.keywords);
     }
 

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -3,7 +3,6 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -30,11 +30,14 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
 
         // instanceof handles nulls
         if (!(other instanceof NameContainsKeywordsPredicate)) {
-            return false;
+            if (other != null) {
+                return false;
+            }
         }
 
         NameContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (NameContainsKeywordsPredicate) other;
-        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
+        return keywords.equals(otherNameContainsKeywordsPredicate != null
+                ? otherNameContainsKeywordsPredicate.keywords : null);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -18,8 +18,9 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
+        // Checks if the string i.e (full name) contains a keyword, allowing partial matching of name via find command
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(keyword -> person.getName().fullName.toLowerCase().contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -29,10 +29,8 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof NameContainsKeywordsPredicate)) {
-            if (other != null) {
-                return false;
-            }
+        if (!(other instanceof NameContainsKeywordsPredicate) && other != null) {
+            return false;
         }
 
         NameContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (NameContainsKeywordsPredicate) other;

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -1,0 +1,44 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s {@code Phone} matches any of the keywords given.
+ */
+public class PhoneContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public PhoneContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        // Checks if the string i.e (phone number) contains a keyword, allowing partial matching of phone number via find command
+        return keywords.stream()
+                .anyMatch(keyword -> person.getPhone().value.contains(keyword.toLowerCase()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof NameContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        PhoneContainsKeywordsPredicate otherPhoneContainsKeywordsPredicate = (PhoneContainsKeywordsPredicate) other;
+        return keywords.equals(otherPhoneContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -25,18 +25,13 @@ public class PhoneContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean equals(Object other) {
-        System.out.println("This is in equals of PhoneContainsPredicate class!");
-        System.out.println(other);
-
         if (other == this) {
             return true;
         }
 
         // instanceof handles nulls
-        if (!(other instanceof PhoneContainsKeywordsPredicate)) {
-            if (other != null) {
-                return false;
-            }
+        if (!(other instanceof PhoneContainsKeywordsPredicate) && other != null) {
+            return false;
         }
 
         PhoneContainsKeywordsPredicate otherPhoneContainsKeywordsPredicate = (PhoneContainsKeywordsPredicate) other;

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -25,17 +25,23 @@ public class PhoneContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean equals(Object other) {
+        System.out.println("This is in equals of PhoneContainsPredicate class!");
+        System.out.println(other);
+
         if (other == this) {
             return true;
         }
 
         // instanceof handles nulls
-        if (!(other instanceof NameContainsKeywordsPredicate)) {
-            return false;
+        if (!(other instanceof PhoneContainsKeywordsPredicate)) {
+            if (other != null) {
+                return false;
+            }
         }
 
         PhoneContainsKeywordsPredicate otherPhoneContainsKeywordsPredicate = (PhoneContainsKeywordsPredicate) other;
-        return keywords.equals(otherPhoneContainsKeywordsPredicate.keywords);
+        return keywords.equals(otherPhoneContainsKeywordsPredicate != null
+                ? otherPhoneContainsKeywordsPredicate.keywords : null);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -17,7 +17,8 @@ public class PhoneContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        // Checks if the string i.e (phone number) contains a keyword, allowing partial matching of phone number via find command
+        // Checks if the string i.e (phone number) contains a keyword,
+        // allowing partial matching of phone number via find command
         return keywords.stream()
                 .anyMatch(keyword -> person.getPhone().value.contains(keyword.toLowerCase()));
     }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
@@ -12,6 +13,7 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,10 +21,9 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
 
-/**
- * Contains integration tests (interaction with the Model) for {@code FindCommand}.
- */
 public class FindCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
@@ -34,14 +35,14 @@ public class FindCommandTest {
         NameContainsKeywordsPredicate secondPredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("second"));
 
-        FindCommand findFirstCommand = new FindCommand(firstPredicate);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate);
+        FindCommand findFirstCommand = new FindCommand(firstPredicate, null, null);
+        FindCommand findSecondCommand = new FindCommand(secondPredicate, null, null);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
+        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate, null, null);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -50,42 +51,118 @@ public class FindCommandTest {
         // null -> returns false
         assertFalse(findFirstCommand.equals(null));
 
-        // different person -> returns false
+        // different predicates -> returns false
         assertFalse(findFirstCommand.equals(findSecondCommand));
     }
 
     @Test
-    public void execute_zeroKeywords_noPersonFound() {
+    public void execute_zeroNameKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindCommand command = new FindCommand(predicate);
+        NameContainsKeywordsPredicate predicate = prepareNamePredicate(" ");
+        FindCommand command = new FindCommand(predicate, null, null);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
     }
 
     @Test
-    public void execute_multipleKeywords_multiplePersonsFound() {
+    public void execute_multipleNameKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
-        FindCommand command = new FindCommand(predicate);
+        NameContainsKeywordsPredicate predicate = prepareNamePredicate("Kurz Elle Kunz");
+        FindCommand command = new FindCommand(predicate, null, null);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
     }
 
     @Test
+    public void execute_phoneKeywords_onePersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        PhoneContainsKeywordsPredicate predicate = preparePhonePredicate("98765432");
+        FindCommand command = new FindCommand(null, predicate, null);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(List.of(BENSON), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multiplePhoneKeywords_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        PhoneContainsKeywordsPredicate predicate = preparePhonePredicate("98765432 95352563 94822249");
+        FindCommand command = new FindCommand(null, predicate, null);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(List.of(BENSON, CARL, ELLE), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_addressKeywords_onePersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        AddressContainsKeywordsPredicate predicate = prepareAddressPredicate("Wall");
+        FindCommand command = new FindCommand(null, null, predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(List.of(CARL), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleAddressKeywords_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        AddressContainsKeywordsPredicate predicate = prepareAddressPredicate("Wall_Michegan Ave_Little Tokyo");
+        FindCommand command = new FindCommand(null, null, predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(List.of(CARL, ELLE, FIONA), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleFields_onePersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("Elle");
+        PhoneContainsKeywordsPredicate phonePredicate = preparePhonePredicate("94822249");
+        AddressContainsKeywordsPredicate addressPredicate = prepareAddressPredicate("Michegan");
+
+        FindCommand command = new FindCommand(namePredicate, phonePredicate, addressPredicate);
+        expectedModel.updateFilteredPersonList(namePredicate.and(phonePredicate).and(addressPredicate));
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ELLE), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleFields_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        NameContainsKeywordsPredicate namePredicate = prepareNamePredicate("elle benson carl");
+        PhoneContainsKeywordsPredicate phonePredicate = preparePhonePredicate("94822249 98765432 95352563");
+        AddressContainsKeywordsPredicate addressPredicate = prepareAddressPredicate("Michegan_Clementi Ave 2_wall");
+
+        FindCommand command = new FindCommand(namePredicate, phonePredicate, addressPredicate);
+        expectedModel.updateFilteredPersonList(namePredicate.and(phonePredicate).and(addressPredicate));
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BENSON, CARL, ELLE), model.getFilteredPersonList());
+    }
+
+    @Test
     public void toStringMethod() {
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
-        FindCommand findCommand = new FindCommand(predicate);
-        String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        NameContainsKeywordsPredicate namePredicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
+        PhoneContainsKeywordsPredicate phonePredicate = new PhoneContainsKeywordsPredicate(Arrays.asList("phone"));
+        FindCommand findCommand = new FindCommand(namePredicate, phonePredicate, null);
+        String expected = FindCommand.class.getCanonicalName() + "{namePredicate=" + namePredicate + ", phonePredicate="
+                + phonePredicate + ", addressPredicate=null}" ;
         assertEquals(expected, findCommand.toString());
     }
 
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
+    private NameContainsKeywordsPredicate prepareNamePredicate(String userInput) {
         return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+    private PhoneContainsKeywordsPredicate preparePhonePredicate(String userInput) {
+        return new PhoneContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+    private AddressContainsKeywordsPredicate prepareAddressPredicate(String userInput) {
+        return new AddressContainsKeywordsPredicate(Arrays.asList(userInput.split("_")));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -36,14 +36,14 @@ public class FindCommandTest {
         NameContainsKeywordsPredicate secondPredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("second"));
 
-        FindCommand findFirstCommand = new FindCommand(firstPredicate, null, null);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate, null, null);
+        FindCommand findFirstCommand = new FindCommand(firstPredicate);
+        FindCommand findSecondCommand = new FindCommand(secondPredicate);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate, null, null);
+        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -60,7 +60,7 @@ public class FindCommandTest {
     public void execute_zeroNameKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate predicate = prepareNamePredicate(" ");
-        FindCommand command = new FindCommand(predicate, null, null);
+        FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
@@ -70,7 +70,7 @@ public class FindCommandTest {
     public void execute_multipleNameKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
         NameContainsKeywordsPredicate predicate = prepareNamePredicate("Kurz Elle Kunz");
-        FindCommand command = new FindCommand(predicate, null, null);
+        FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
@@ -80,7 +80,7 @@ public class FindCommandTest {
     public void execute_phoneKeywords_onePersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
         PhoneContainsKeywordsPredicate predicate = preparePhonePredicate("98765432");
-        FindCommand command = new FindCommand(null, predicate, null);
+        FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(List.of(BENSON), model.getFilteredPersonList());
@@ -90,7 +90,7 @@ public class FindCommandTest {
     public void execute_multiplePhoneKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
         PhoneContainsKeywordsPredicate predicate = preparePhonePredicate("98765432 95352563 94822249");
-        FindCommand command = new FindCommand(null, predicate, null);
+        FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(List.of(BENSON, CARL, ELLE), model.getFilteredPersonList());
@@ -100,7 +100,7 @@ public class FindCommandTest {
     public void execute_addressKeywords_onePersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
         AddressContainsKeywordsPredicate predicate = prepareAddressPredicate("Wall");
-        FindCommand command = new FindCommand(null, null, predicate);
+        FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(List.of(CARL), model.getFilteredPersonList());
@@ -110,7 +110,7 @@ public class FindCommandTest {
     public void execute_multipleAddressKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
         AddressContainsKeywordsPredicate predicate = prepareAddressPredicate("Wall_Michegan Ave_Little Tokyo");
-        FindCommand command = new FindCommand(null, null, predicate);
+        FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(List.of(CARL, ELLE, FIONA), model.getFilteredPersonList());
@@ -146,7 +146,7 @@ public class FindCommandTest {
     public void toStringMethod() {
         NameContainsKeywordsPredicate namePredicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
         PhoneContainsKeywordsPredicate phonePredicate = new PhoneContainsKeywordsPredicate(Arrays.asList("phone"));
-        FindCommand findCommand = new FindCommand(namePredicate, phonePredicate, null);
+        FindCommand findCommand = new FindCommand(namePredicate, phonePredicate);
         String expected = FindCommand.class.getCanonicalName() + "{namePredicate=" + namePredicate + ", phonePredicate="
                 + phonePredicate + ", addressPredicate=null}";
         assertEquals(expected, findCommand.toString());

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -20,9 +20,10 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.PhoneContainsKeywordsPredicate;
-import seedu.address.model.person.AddressContainsKeywordsPredicate;
+
 
 public class FindCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
@@ -147,7 +148,7 @@ public class FindCommandTest {
         PhoneContainsKeywordsPredicate phonePredicate = new PhoneContainsKeywordsPredicate(Arrays.asList("phone"));
         FindCommand findCommand = new FindCommand(namePredicate, phonePredicate, null);
         String expected = FindCommand.class.getCanonicalName() + "{namePredicate=" + namePredicate + ", phonePredicate="
-                + phonePredicate + ", addressPredicate=null}" ;
+                + phonePredicate + ", addressPredicate=null}";
         assertEquals(expected, findCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -80,22 +80,22 @@ public class AddressBookParserTest {
         List<String> nameKeywords = Arrays.asList("foo", "bar", "baz");
         FindCommand nameCommand = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + PREFIX_NAME + nameKeywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(nameKeywords), null, null), nameCommand);
+        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(nameKeywords)), nameCommand);
 
         // Test find on phone
         List<String> phoneKeywords = Arrays.asList("12345678", "92631731");
         FindCommand phoneCommand = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + PREFIX_PHONE
                         + phoneKeywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(null, new PhoneContainsKeywordsPredicate(phoneKeywords), null), phoneCommand);
+        assertEquals(new FindCommand(new PhoneContainsKeywordsPredicate(phoneKeywords)), phoneCommand);
 
         // Test find on address
         List<String> addressKeywords = Arrays.asList("blk 50", "blk 49");
         FindCommand addressCommand = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + PREFIX_ADDRESS
                         + addressKeywords.stream().collect(Collectors.joining("_")));
-        assertEquals(new FindCommand(null, null,
-                new AddressContainsKeywordsPredicate(addressKeywords)), addressCommand);
+        assertEquals(new FindCommand(new AddressContainsKeywordsPredicate(addressKeywords)),
+                addressCommand);
 
         // Test find on multiple fields (name, phone, address)
         FindCommand combinedCommand = (FindCommand) parser.parseCommand(

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -85,14 +85,17 @@ public class AddressBookParserTest {
         // Test find on phone
         List<String> phoneKeywords = Arrays.asList("12345678", "92631731");
         FindCommand phoneCommand = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + PREFIX_PHONE + phoneKeywords.stream().collect(Collectors.joining(" ")));
+                FindCommand.COMMAND_WORD + " " + PREFIX_PHONE
+                        + phoneKeywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(null, new PhoneContainsKeywordsPredicate(phoneKeywords), null), phoneCommand);
 
         // Test find on address
         List<String> addressKeywords = Arrays.asList("blk 50", "blk 49");
         FindCommand addressCommand = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + PREFIX_ADDRESS + addressKeywords.stream().collect(Collectors.joining("_")));
-        assertEquals(new FindCommand(null, null, new AddressContainsKeywordsPredicate(addressKeywords)), addressCommand);
+                FindCommand.COMMAND_WORD + " " + PREFIX_ADDRESS
+                        + addressKeywords.stream().collect(Collectors.joining("_")));
+        assertEquals(new FindCommand(null, null,
+                new AddressContainsKeywordsPredicate(addressKeywords)), addressCommand);
 
         // Test find on multiple fields (name, phone, address)
         FindCommand combinedCommand = (FindCommand) parser.parseCommand(

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.LIST_MESSAGE_INVALID_COMMAND;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -24,8 +27,10 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -71,10 +76,34 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_find() throws Exception {
-        List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        // Test find on name
+        List<String> nameKeywords = Arrays.asList("foo", "bar", "baz");
+        FindCommand nameCommand = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " " + PREFIX_NAME + nameKeywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(nameKeywords), null, null), nameCommand);
+
+        // Test find on phone
+        List<String> phoneKeywords = Arrays.asList("12345678", "92631731");
+        FindCommand phoneCommand = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " " + PREFIX_PHONE + phoneKeywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(null, new PhoneContainsKeywordsPredicate(phoneKeywords), null), phoneCommand);
+
+        // Test find on address
+        List<String> addressKeywords = Arrays.asList("blk 50", "blk 49");
+        FindCommand addressCommand = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " " + PREFIX_ADDRESS + addressKeywords.stream().collect(Collectors.joining("_")));
+        assertEquals(new FindCommand(null, null, new AddressContainsKeywordsPredicate(addressKeywords)), addressCommand);
+
+        // Test find on multiple fields (name, phone, address)
+        FindCommand combinedCommand = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " " + PREFIX_NAME + "foo bar "
+                        + PREFIX_PHONE + "12345678 " + PREFIX_ADDRESS + "blk 50");
+
+        assertEquals(new FindCommand(
+                        new NameContainsKeywordsPredicate(Arrays.asList("foo", "bar")),
+                        new PhoneContainsKeywordsPredicate(Arrays.asList("12345678")),
+                        new AddressContainsKeywordsPredicate(Arrays.asList("blk 50"))),
+                combinedCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -39,7 +39,8 @@ public class FindCommandParserTest {
 
         // whitespaces allowed in address and multiple "_" between address keywords
         FindCommand expectedFindCommandForAddress =
-                new FindCommand(null, null, new AddressContainsKeywordsPredicate(Arrays.asList("Wall Street", "Michigan")));
+                new FindCommand(null, null,
+                        new AddressContainsKeywordsPredicate(Arrays.asList("Wall Street", "Michigan")));
         assertParseSuccess(parser, " a/Wall Street_Michigan", expectedFindCommandForAddress);
     }
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -26,7 +26,7 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces on names
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")), null, null);
+                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
         assertParseSuccess(parser, " n/Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between name keywords
@@ -34,13 +34,12 @@ public class FindCommandParserTest {
 
         // multiple whitespaces between phone keywords
         FindCommand expectedFindCommandForPhone =
-                new FindCommand(null, new PhoneContainsKeywordsPredicate(Arrays.asList("9345", "1234")), null);
+                new FindCommand(new PhoneContainsKeywordsPredicate(Arrays.asList("9345", "1234")));
         assertParseSuccess(parser, " p/9345 1234", expectedFindCommandForPhone);
 
         // whitespaces allowed in address and multiple "_" between address keywords
         FindCommand expectedFindCommandForAddress =
-                new FindCommand(null, null,
-                        new AddressContainsKeywordsPredicate(Arrays.asList("Wall Street", "Michigan")));
+                new FindCommand(new AddressContainsKeywordsPredicate(Arrays.asList("Wall Street", "Michigan")));
         assertParseSuccess(parser, " a/Wall Street_Michigan", expectedFindCommandForAddress);
     }
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -9,7 +9,9 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -22,13 +24,23 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsFindCommand() {
-        // no leading and trailing whitespaces
+        // no leading and trailing whitespaces on names
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")), null, null);
+        assertParseSuccess(parser, " n/Alice Bob", expectedFindCommand);
 
-        // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        // multiple whitespaces between name keywords
+        assertParseSuccess(parser, " n/ \n Alice \n \t Bob  \t", expectedFindCommand);
+
+        // multiple whitespaces between phone keywords
+        FindCommand expectedFindCommandForPhone =
+                new FindCommand(null, new PhoneContainsKeywordsPredicate(Arrays.asList("9345", "1234")), null);
+        assertParseSuccess(parser, " p/9345 1234", expectedFindCommandForPhone);
+
+        // whitespaces allowed in address and multiple "_" between address keywords
+        FindCommand expectedFindCommandForAddress =
+                new FindCommand(null, null, new AddressContainsKeywordsPredicate(Arrays.asList("Wall Street", "Michigan")));
+        assertParseSuccess(parser, " a/Wall Street_Michigan", expectedFindCommandForAddress);
     }
 
 }

--- a/src/test/java/seedu/address/model/person/AddressContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/AddressContainsKeywordsPredicateTest.java
@@ -1,0 +1,81 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class AddressContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        AddressContainsKeywordsPredicate firstPredicate = new AddressContainsKeywordsPredicate(firstPredicateKeywordList);
+        AddressContainsKeywordsPredicate secondPredicate = new AddressContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        AddressContainsKeywordsPredicate firstPredicateCopy = new AddressContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_addressContainsKeywords_returnsTrue() {
+        // One keyword
+        AddressContainsKeywordsPredicate predicate = new AddressContainsKeywordsPredicate(Collections.singletonList("wall street"));
+        assertTrue(predicate.test(new PersonBuilder().withAddress("wall street").build()));
+
+        // Multiple keywords
+        predicate = new AddressContainsKeywordsPredicate(Arrays.asList("wall", "street"));
+        assertTrue(predicate.test(new PersonBuilder().withAddress("wall street").build()));
+
+        // Only one matching keyword
+        predicate = new AddressContainsKeywordsPredicate(Arrays.asList("wall", "michigan"));
+        assertTrue(predicate.test(new PersonBuilder().withAddress("wall street").build()));
+    }
+
+    @Test
+    public void test_addressDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        AddressContainsKeywordsPredicate predicate = new AddressContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withAddress("12345678").build()));
+
+        // Non-matching keyword
+        predicate = new AddressContainsKeywordsPredicate(Arrays.asList("7899"));
+        assertFalse(predicate.test(new PersonBuilder().withAddress("12345678").build()));
+
+        // Keywords match name, email and phone, but does not match address
+        predicate = new AddressContainsKeywordsPredicate(Arrays.asList("Alice", "alice@email.com", "1234"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345678")
+                .withEmail("alice@email.com").withAddress("Main Street").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<String> keywords = List.of("keyword1", "keyword2");
+        AddressContainsKeywordsPredicate predicate = new AddressContainsKeywordsPredicate(keywords);
+
+        String expected = AddressContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/AddressContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/AddressContainsKeywordsPredicateTest.java
@@ -19,14 +19,17 @@ public class AddressContainsKeywordsPredicateTest {
         List<String> firstPredicateKeywordList = Collections.singletonList("first");
         List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
 
-        AddressContainsKeywordsPredicate firstPredicate = new AddressContainsKeywordsPredicate(firstPredicateKeywordList);
-        AddressContainsKeywordsPredicate secondPredicate = new AddressContainsKeywordsPredicate(secondPredicateKeywordList);
+        AddressContainsKeywordsPredicate firstPredicate =
+                new AddressContainsKeywordsPredicate(firstPredicateKeywordList);
+        AddressContainsKeywordsPredicate secondPredicate =
+                new AddressContainsKeywordsPredicate(secondPredicateKeywordList);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        AddressContainsKeywordsPredicate firstPredicateCopy = new AddressContainsKeywordsPredicate(firstPredicateKeywordList);
+        AddressContainsKeywordsPredicate firstPredicateCopy =
+                new AddressContainsKeywordsPredicate(firstPredicateKeywordList);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -42,7 +45,8 @@ public class AddressContainsKeywordsPredicateTest {
     @Test
     public void test_addressContainsKeywords_returnsTrue() {
         // One keyword
-        AddressContainsKeywordsPredicate predicate = new AddressContainsKeywordsPredicate(Collections.singletonList("wall street"));
+        AddressContainsKeywordsPredicate predicate =
+                new AddressContainsKeywordsPredicate(Collections.singletonList("wall street"));
         assertTrue(predicate.test(new PersonBuilder().withAddress("wall street").build()));
 
         // Multiple keywords

--- a/src/test/java/seedu/address/model/person/PhoneContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneContainsKeywordsPredicateTest.java
@@ -26,7 +26,8 @@ public class PhoneContainsKeywordsPredicateTest {
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        PhoneContainsKeywordsPredicate firstPredicateCopy = new PhoneContainsKeywordsPredicate(firstPredicateKeywordList);
+        PhoneContainsKeywordsPredicate firstPredicateCopy =
+                new PhoneContainsKeywordsPredicate(firstPredicateKeywordList);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -42,7 +43,8 @@ public class PhoneContainsKeywordsPredicateTest {
     @Test
     public void test_phoneContainsKeywords_returnsTrue() {
         // One keyword
-        PhoneContainsKeywordsPredicate predicate = new PhoneContainsKeywordsPredicate(Collections.singletonList("12345678"));
+        PhoneContainsKeywordsPredicate predicate =
+                new PhoneContainsKeywordsPredicate(Collections.singletonList("12345678"));
         assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").build()));
 
         // Multiple keywords

--- a/src/test/java/seedu/address/model/person/PhoneContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneContainsKeywordsPredicateTest.java
@@ -1,0 +1,81 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class PhoneContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        PhoneContainsKeywordsPredicate firstPredicate = new PhoneContainsKeywordsPredicate(firstPredicateKeywordList);
+        PhoneContainsKeywordsPredicate secondPredicate = new PhoneContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        PhoneContainsKeywordsPredicate firstPredicateCopy = new PhoneContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_phoneContainsKeywords_returnsTrue() {
+        // One keyword
+        PhoneContainsKeywordsPredicate predicate = new PhoneContainsKeywordsPredicate(Collections.singletonList("12345678"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+
+        // Multiple keywords
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("1234", "5678"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+
+        // Only one matching keyword
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("1234", "5678"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("12349876").build()));
+    }
+
+    @Test
+    public void test_phoneDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        PhoneContainsKeywordsPredicate predicate = new PhoneContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+
+        // Non-matching keyword
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("7899"));
+        assertFalse(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+
+        // Keywords match name, email and address, but does not match phone
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("Alice", "alice@email.com", "Main", "Street"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345678")
+                .withEmail("alice@email.com").withAddress("Main Street").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<String> keywords = List.of("keyword1", "keyword2");
+        PhoneContainsKeywordsPredicate predicate = new PhoneContainsKeywordsPredicate(keywords);
+
+        String expected = PhoneContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}


### PR DESCRIPTION
closes #77 
This PR improves the existing find command to allow users to search via specific fields or via multiple fields.