### PR TITLE
Make date of last visit optional

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -79,6 +79,9 @@ public class Messages {
     }
 
     private static void addTags(StringBuilder sb, Person person) {
+        if (person.getTags().isEmpty()) {
+            return;
+        }
         sb.append("; Tags: ");
         person.getTags().forEach(sb::append);
     }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -58,7 +58,10 @@ public class Messages {
     }
 
     private static void addDateOfLastVisit(StringBuilder sb, Person person) {
-        sb.append("; Last visit: ").append(person.getDateOfLastVisit());
+        if (!person.hasDateOfLastVisit()) {
+            return;
+        }
+        sb.append("; Last visit: ").append(person.getDateOfLastVisit().get());
     }
 
     private static void addEmail(StringBuilder sb, Person person) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -45,8 +45,8 @@ public class EditCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_TAG + "TAG] "
-            + "[" + PREFIX_DATEOFLASTVISIT + "DATEOFLASTVISIT]...\n"
+            + "[" + PREFIX_TAG + "TAG]... "
+            + "[" + PREFIX_DATEOFLASTVISIT + "DATEOFLASTVISIT] \n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
@@ -103,10 +103,10 @@ public class EditCommand extends Command {
         Optional<Email> updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Optional<Address> updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
-        DateOfLastVisit dateOfLastVisit = editPersonDescriptor.getDateOfLastVisit()
+        Optional<DateOfLastVisit> updatedDateOfLastVisit = editPersonDescriptor.getDateOfLastVisit()
                 .orElse(personToEdit.getDateOfLastVisit());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, dateOfLastVisit);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedDateOfLastVisit);
     }
 
     @Override
@@ -143,7 +143,7 @@ public class EditCommand extends Command {
         private Optional<Email> email;
         private Optional<Address> address;
         private Set<Tag> tags;
-        private DateOfLastVisit dateOfLastVisit;
+        private Optional<DateOfLastVisit> dateOfLastVisit;
 
         public EditPersonDescriptor() {}
 
@@ -216,11 +216,11 @@ public class EditCommand extends Command {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
         }
 
-        public void setDateOfLastVisit(DateOfLastVisit dateOfLastVisit) {
+        public void setDateOfLastVisit(Optional<DateOfLastVisit> dateOfLastVisit) {
             this.dateOfLastVisit = dateOfLastVisit;
         }
 
-        public Optional<DateOfLastVisit> getDateOfLastVisit() {
+        public Optional<Optional<DateOfLastVisit>> getDateOfLastVisit() {
             return Optional.ofNullable(dateOfLastVisit);
         }
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -37,7 +37,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_TAG, PREFIX_DATEOFLASTVISIT);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_DATEOFLASTVISIT)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
@@ -49,8 +49,8 @@ public class AddCommandParser implements Parser<AddCommand> {
         Optional<Email> email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL));
         Optional<Address> address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS));
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-        DateOfLastVisit dateOfLastVisit = ParserUtil
-                .parseDateOfLastVisit(argMultimap.getValue(PREFIX_DATEOFLASTVISIT).get());
+        Optional<DateOfLastVisit> dateOfLastVisit = ParserUtil
+                .parseDateOfLastVisit(argMultimap.getValue(PREFIX_DATEOFLASTVISIT));
 
         Person person = new Person(name, phone, email, address, tagList, dateOfLastVisit);
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -64,7 +64,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
         if (argMultimap.getValue(PREFIX_DATEOFLASTVISIT).isPresent()) {
             editPersonDescriptor.setDateOfLastVisit(
-                    ParserUtil.parseDateOfLastVisit(argMultimap.getValue(PREFIX_DATEOFLASTVISIT).get()));
+                    ParserUtil.parseDateOfLastVisit(argMultimap.getValue(PREFIX_DATEOFLASTVISIT)));
         }
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -141,12 +141,18 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code dateOfLastVisit} is invalid.
      */
-    public static DateOfLastVisit parseDateOfLastVisit(String dateOfLastVisit) throws ParseException {
+    public static Optional<DateOfLastVisit> parseDateOfLastVisit(Optional<String> dateOfLastVisit) throws ParseException {
         requireNonNull(dateOfLastVisit);
-        String trimmedDateOfLastVisit = dateOfLastVisit.trim();
+
+        if (dateOfLastVisit.isEmpty()) {
+            // if dateOfLastVisit prefix was never entered by the user
+            return Optional.empty();
+        }
+
+        String trimmedDateOfLastVisit = dateOfLastVisit.get().trim();
         if (!DateOfLastVisit.isValidDateOfLastVisit(trimmedDateOfLastVisit)) {
             throw new ParseException(DateOfLastVisit.MESSAGE_CONSTRAINTS);
         }
-        return new DateOfLastVisit(trimmedDateOfLastVisit);
+        return Optional.of(new DateOfLastVisit(trimmedDateOfLastVisit));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -141,7 +141,8 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code dateOfLastVisit} is invalid.
      */
-    public static Optional<DateOfLastVisit> parseDateOfLastVisit(Optional<String> dateOfLastVisit) throws ParseException {
+    public static Optional<DateOfLastVisit> parseDateOfLastVisit(Optional<String> dateOfLastVisit)
+            throws ParseException {
         requireNonNull(dateOfLastVisit);
 
         if (dateOfLastVisit.isEmpty()) {

--- a/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
@@ -6,7 +6,7 @@ import java.util.function.Predicate;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
- * Tests that a {@code Person}'s {@code Phone} matches any of the keywords given.
+ * Tests that a {@code Person}'s {@code Address} matches any of the keywords given.
  */
 public class AddressContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -25,13 +25,13 @@ public class Person {
     private final Optional<Address> address;
     private final Optional<Email> email;
     private final Set<Tag> tags = new HashSet<>();
-    private final DateOfLastVisit dateOfLastVisit;
+    private final Optional<DateOfLastVisit> dateOfLastVisit;
 
     /**
      * Every field must be present and not null.
      */
     public Person(Name name, Phone phone, Optional<Email> email, Optional<Address> address,
-                  Set<Tag> tags, DateOfLastVisit dateOfLastVisit) {
+                  Set<Tag> tags, Optional<DateOfLastVisit> dateOfLastVisit) {
         requireAllNonNull(name, phone, email, address, tags, dateOfLastVisit);
         this.name = name;
         this.phone = phone;
@@ -71,7 +71,14 @@ public class Person {
         return address;
     }
 
-    public DateOfLastVisit getDateOfLastVisit() {
+    /**
+     * Returns whether the Person has a dateOfLastVisit.
+     */
+    public boolean hasDateOfLastVisit() {
+        return dateOfLastVisit.isPresent();
+    }
+
+    public Optional<DateOfLastVisit> getDateOfLastVisit() {
         return dateOfLastVisit;
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -23,23 +23,23 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), Optional.of(new Email("alexyeoh@example.com")),
                     Optional.of(new Address("Blk 30 Geylang Street 29, #06-40")), getTagSet("friends"),
-                    new DateOfLastVisit("01-01-2024")),
+                    Optional.of(new DateOfLastVisit("01-01-2024"))),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), Optional.of(new Email("berniceyu@example.com")),
                     Optional.of(new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18")),
-                    getTagSet("colleagues", "friends"), new DateOfLastVisit("02-02-2024")),
+                    getTagSet("colleagues", "friends"), Optional.of(new DateOfLastVisit("02-02-2024"))),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"),
                     Optional.of(new Email("charlotte@example.com")),
                     Optional.of(new Address("Blk 11 Ang Mo Kio Street 74, #11-04")),
-                    getTagSet("neighbours"), new DateOfLastVisit("03-03-2024")),
+                    getTagSet("neighbours"), Optional.of(new DateOfLastVisit("03-03-2024"))),
             new Person(new Name("David Li"), new Phone("91031282"), Optional.of(new Email("lidavid@example.com")),
                 Optional.of(new Address("Blk 436 Serangoon Gardens Street 26, #16-43")),
-                getTagSet("family"), new DateOfLastVisit("04-04-2024")),
+                getTagSet("family"), Optional.of(new DateOfLastVisit("04-04-2024"))),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), Optional.of(new Email("irfan@example.com")),
                 Optional.of(new Address("Blk 47 Tampines Street 20, #17-35")),
-                getTagSet("classmates"), new DateOfLastVisit("05-05-2024")),
+                getTagSet("classmates"), Optional.of(new DateOfLastVisit("05-05-2024"))),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), Optional.of(new Email("royb@example.com")),
                 Optional.of(new Address("Blk 45 Aljunied Street 85, #11-31")),
-                getTagSet("colleagues"), new DateOfLastVisit("06-06-2024"))
+                getTagSet("colleagues"), Optional.of(new DateOfLastVisit("06-06-2024")))
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -25,7 +25,7 @@ import seedu.address.model.tag.Tag;
 class JsonAdaptedPerson {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
-    private static final String EMPTY_ADDRESS_OR_EMAIL_STRING = "";
+    private static final String EMPTY_DATA_FIELD_STRING = "";
 
     private final String name;
     private final String phone;
@@ -57,12 +57,13 @@ class JsonAdaptedPerson {
     public JsonAdaptedPerson(Person source) {
         name = source.getName().fullName;
         phone = source.getPhone().value;
-        email = source.hasEmail() ? source.getEmail().get().value : EMPTY_ADDRESS_OR_EMAIL_STRING;
-        address = source.hasAddress() ? source.getAddress().get().value : EMPTY_ADDRESS_OR_EMAIL_STRING;
+        email = source.hasEmail() ? source.getEmail().get().value : EMPTY_DATA_FIELD_STRING;
+        address = source.hasAddress() ? source.getAddress().get().value : EMPTY_DATA_FIELD_STRING;
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
-        dateOfLastVisit = source.getDateOfLastVisit().value;
+        dateOfLastVisit = source.hasDateOfLastVisit()
+                ? source.getDateOfLastVisit().get().value : EMPTY_DATA_FIELD_STRING;
     }
 
     /**
@@ -118,14 +119,18 @@ class JsonAdaptedPerson {
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
 
+        Optional<DateOfLastVisit> modelDateOfLastVisit;
         if (dateOfLastVisit == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     DateOfLastVisit.class.getSimpleName()));
         }
-        if (!DateOfLastVisit.isValidDateOfLastVisit(dateOfLastVisit)) {
+        if (dateOfLastVisit.isEmpty()) {
+            modelDateOfLastVisit = Optional.empty();
+        } else if (!DateOfLastVisit.isValidDateOfLastVisit(dateOfLastVisit)) {
             throw new IllegalValueException(DateOfLastVisit.MESSAGE_CONSTRAINTS);
+        } else {
+            modelDateOfLastVisit = Optional.of(new DateOfLastVisit(dateOfLastVisit));
         }
-        final DateOfLastVisit modelDateOfLastVisit = new DateOfLastVisit(dateOfLastVisit);
 
         return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags, modelDateOfLastVisit);
     }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -57,6 +57,8 @@ public class PersonCard extends UiPart<Region> {
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
-        dateOfLastVisit.setText("Date last visited: " + person.getDateOfLastVisit().value);
+        dateOfLastVisit.setText(person.hasDateOfLastVisit()
+                ? "Date last visited: " + person.getDateOfLastVisit().get().value
+                : "");
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -72,15 +73,34 @@ public class AddCommandTest {
     }
 
     @Test
-    public void execute_personWithoutEmailOrAddress_addSuccessful() throws Exception {
+    public void execute_personWithoutDateOfLastVisit_addSuccessful() throws Exception {
         ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
 
-        Person personWithoutEmailOrAddress = new PersonBuilder(CARL).withEmail().withAddress().build();
-        CommandResult commandResultWithoutEmailOrAddress = new AddCommand(personWithoutEmailOrAddress)
+        Person personWithoutDateOfLastVisit = new PersonBuilder(DANIEL).withDateOfLastVisit().build();
+        CommandResult commandResultWithoutDateOfLastVisit = new AddCommand(personWithoutDateOfLastVisit)
                 .execute(modelStub);
-        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(personWithoutEmailOrAddress)),
-                commandResultWithoutEmailOrAddress.getFeedbackToUser());
-        assertEquals(Arrays.asList(personWithoutEmailOrAddress),
+
+        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(personWithoutDateOfLastVisit)),
+                commandResultWithoutDateOfLastVisit.getFeedbackToUser());
+        assertEquals(Arrays.asList(personWithoutDateOfLastVisit),
+                modelStub.personsAdded);
+    }
+
+    @Test
+    public void execute_personWithoutEmailOrAddressOrDateOfLastVisit_addSuccessful() throws Exception {
+        ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
+
+        Person personWithoutEmailOrAddressOrDateOfLastVisit = new PersonBuilder(CARL)
+                .withEmail()
+                .withAddress()
+                .withDateOfLastVisit().build();
+        CommandResult commandResultWithoutEmailOrAddressOrDateOfLastVisit =
+                new AddCommand(personWithoutEmailOrAddressOrDateOfLastVisit)
+                .execute(modelStub);
+        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, Messages
+                        .format(personWithoutEmailOrAddressOrDateOfLastVisit)),
+                commandResultWithoutEmailOrAddressOrDateOfLastVisit.getFeedbackToUser());
+        assertEquals(Arrays.asList(personWithoutEmailOrAddressOrDateOfLastVisit),
                 modelStub.personsAdded);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -167,11 +167,29 @@ public class AddCommandParserTest {
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                         + DATEOFLASTVISIT_DESC_BOB, new AddCommand(expectedPersonWithoutAddress));
 
+        // no dateOfLastVisit provided
+        Person expectedPersonWithoutDateOfLastVisit = new PersonBuilder(BOB)
+                .withDateOfLastVisit().withTags().build();
+        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB,
+                new AddCommand(expectedPersonWithoutDateOfLastVisit));
+
         // no email or address provided
         Person expectedPersonWithoutAddressOrEmail = new PersonBuilder(BOB)
                 .withAddress().withEmail().withTags().build();
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + DATEOFLASTVISIT_DESC_BOB,
                 new AddCommand(expectedPersonWithoutAddressOrEmail));
+
+        // no email or dateOfLastVisit provided
+        Person expectedPersonWithoutEmailOrDateOfLastVisit = new PersonBuilder(BOB)
+                .withEmail().withTags().withDateOfLastVisit().build();
+        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + ADDRESS_DESC_BOB,
+                new AddCommand(expectedPersonWithoutEmailOrDateOfLastVisit));
+
+        // no address or dateOfLastVisit provided
+        Person expectedPersonWithoutAddressOrDateOfLastVisit = new PersonBuilder(BOB)
+                .withAddress().withTags().withDateOfLastVisit().build();
+        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB,
+                new AddCommand(expectedPersonWithoutAddressOrDateOfLastVisit));
     }
 
     @Test
@@ -185,10 +203,6 @@ public class AddCommandParserTest {
         // missing phone prefix
         assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                         + DATEOFLASTVISIT_DESC_BOB, expectedMessage);
-
-        // missing dateOfLastVisit prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                        + VALID_DATEOFLASTVISIT_BOB, expectedMessage);
 
         // all prefixes missing
         assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -203,25 +203,28 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseDateOfLastVisit_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> ParserUtil.parseDateOfLastVisit((String) null));
+    public void parseDateOfLastVisit_null_throwsNullPointerException() throws Exception {
+        assertEquals(Optional.empty(),
+                ParserUtil.parseDateOfLastVisit(Optional.ofNullable((String) null)));
     }
-
     @Test
     public void parseDateOfLastVisit_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseDateOfLastVisit(INVALID_DATEOFLASTVISIT));
+        assertThrows(ParseException.class, () ->
+                ParserUtil.parseDateOfLastVisit(Optional.of(INVALID_DATEOFLASTVISIT)));
     }
 
     @Test
     public void parseDateOfLastVisit_validValueWithoutWhitespace_returnsDateOfLastVisit() throws Exception {
         DateOfLastVisit expectedDateOfLastVisit = new DateOfLastVisit(VALID_DATEOFLASTVISIT);
-        assertEquals(expectedDateOfLastVisit, ParserUtil.parseDateOfLastVisit(VALID_DATEOFLASTVISIT));
+        assertEquals(Optional.of(expectedDateOfLastVisit),
+                ParserUtil.parseDateOfLastVisit(Optional.of(VALID_DATEOFLASTVISIT)));
     }
 
     @Test
     public void parseDateOfLastVisit_validValueWithWhitespace_returnsTrimmedDateOfLastVisit() throws Exception {
         String dateOfLastVisitWithWhitespace = WHITESPACE + VALID_DATEOFLASTVISIT + WHITESPACE;
         DateOfLastVisit expectedDateOfLastVisit = new DateOfLastVisit(VALID_DATEOFLASTVISIT);
-        assertEquals(expectedDateOfLastVisit, ParserUtil.parseDateOfLastVisit(dateOfLastVisitWithWhitespace));
+        assertEquals(Optional.of(expectedDateOfLastVisit),
+                ParserUtil.parseDateOfLastVisit(Optional.of(dateOfLastVisitWithWhitespace)));
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -191,7 +191,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_noAddressNoDateOfLastVisit_returnsPerson() throws Exception {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                VALID_EMPTY_FIELD, VALID_TAGS, VALID_DATEOFLASTVISIT);
+                VALID_EMPTY_FIELD, VALID_TAGS, VALID_EMPTY_FIELD);
         String[] validTagsInString = VALID_TAGS.stream().map(tag -> tag.getTagName()).toArray(String[]::new);
         Person expectedPerson = new PersonBuilder().withName(VALID_NAME).withPhone(VALID_PHONE)
                 .withEmail(VALID_EMAIL).withAddress().withTags(validTagsInString)

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -37,7 +37,7 @@ public class JsonAdaptedPersonTest {
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
-    private static final String VALID_DATEOFLASTVISIT = BENSON.getDateOfLastVisit().toString();
+    private static final String VALID_DATEOFLASTVISIT = BENSON.getDateOfLastVisit().get().toString();
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
@@ -167,6 +167,17 @@ public class JsonAdaptedPersonTest {
     }
 
     @Test
+    public void toModelType_noDateOfLastVisit_returnsPerson() throws Exception {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                VALID_ADDRESS, VALID_TAGS, VALID_EMPTY_FIELD);
+        String[] validTagsInString = VALID_TAGS.stream().map(tag -> tag.getTagName()).toArray(String[]::new);
+        Person expectedPerson = new PersonBuilder().withName(VALID_NAME).withPhone(VALID_PHONE)
+                .withEmail(VALID_EMAIL).withAddress(VALID_ADDRESS).withTags(validTagsInString)
+                .withDateOfLastVisit().build();
+        assertEquals(expectedPerson, person.toModelType());
+    }
+
+    @Test
     public void toModelType_noAddressNoEmail_returnsPerson() throws Exception {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMPTY_FIELD,
                 VALID_EMPTY_FIELD, VALID_TAGS, VALID_DATEOFLASTVISIT);
@@ -174,6 +185,39 @@ public class JsonAdaptedPersonTest {
         Person expectedPerson = new PersonBuilder().withName(VALID_NAME).withPhone(VALID_PHONE)
                 .withEmail().withAddress().withTags(validTagsInString)
                 .withDateOfLastVisit(VALID_DATEOFLASTVISIT).build();
+        assertEquals(expectedPerson, person.toModelType());
+    }
+
+    @Test
+    public void toModelType_noAddressNoDateOfLastVisit_returnsPerson() throws Exception {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                VALID_EMPTY_FIELD, VALID_TAGS, VALID_DATEOFLASTVISIT);
+        String[] validTagsInString = VALID_TAGS.stream().map(tag -> tag.getTagName()).toArray(String[]::new);
+        Person expectedPerson = new PersonBuilder().withName(VALID_NAME).withPhone(VALID_PHONE)
+                .withEmail(VALID_EMAIL).withAddress().withTags(validTagsInString)
+                .withDateOfLastVisit().build();
+        assertEquals(expectedPerson, person.toModelType());
+    }
+
+    @Test
+    public void toModelType_noEmailNoDateOfLastVisit_returnsPerson() throws Exception {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMPTY_FIELD,
+                VALID_ADDRESS, VALID_TAGS, VALID_EMPTY_FIELD);
+        String[] validTagsInString = VALID_TAGS.stream().map(tag -> tag.getTagName()).toArray(String[]::new);
+        Person expectedPerson = new PersonBuilder().withName(VALID_NAME).withPhone(VALID_PHONE)
+                .withEmail().withAddress(VALID_ADDRESS).withTags(validTagsInString)
+                .withDateOfLastVisit().build();
+        assertEquals(expectedPerson, person.toModelType());
+    }
+
+    @Test
+    public void toModelType_noAddressNoEmailNoDateOfLastVisit_returnsPerson() throws Exception {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMPTY_FIELD,
+                VALID_EMPTY_FIELD, VALID_TAGS, VALID_EMPTY_FIELD);
+        String[] validTagsInString = VALID_TAGS.stream().map(tag -> tag.getTagName()).toArray(String[]::new);
+        Person expectedPerson = new PersonBuilder().withName(VALID_NAME).withPhone(VALID_PHONE)
+                .withEmail().withAddress().withTags(validTagsInString)
+                .withDateOfLastVisit().build();
         assertEquals(expectedPerson, person.toModelType());
     }
 }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -88,7 +88,7 @@ public class EditPersonDescriptorBuilder {
      * Sets the {@code DateOfLastVisit} of the {@code EditPersonDescriptor} that we are building.
      */
     public EditPersonDescriptorBuilder withDateOfLastVisit(String dateOfLastVisit) {
-        descriptor.setDateOfLastVisit(new DateOfLastVisit(dateOfLastVisit));
+        descriptor.setDateOfLastVisit(Optional.of(new DateOfLastVisit(dateOfLastVisit)));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -13,6 +13,8 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
+import javax.swing.text.html.Option;
+
 /**
  * A utility class to help with building Person objects.
  */
@@ -29,7 +31,7 @@ public class PersonBuilder {
     private Optional<Email> email;
     private Optional<Address> address;
     private Set<Tag> tags;
-    private DateOfLastVisit dateOfLastVisit;
+    private Optional<DateOfLastVisit> dateOfLastVisit;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -40,7 +42,7 @@ public class PersonBuilder {
         email = Optional.of(new Email(DEFAULT_EMAIL));
         address = Optional.of(new Address(DEFAULT_ADDRESS));
         tags = new HashSet<>();
-        dateOfLastVisit = new DateOfLastVisit(DEFAULT_DATEOFLASTVISIT);
+        dateOfLastVisit = Optional.of(new DateOfLastVisit(DEFAULT_DATEOFLASTVISIT));
     }
 
     /**
@@ -115,7 +117,15 @@ public class PersonBuilder {
      * Sets the {@code DateOfLastVisit} of the {@code Person} that we are building.
      */
     public PersonBuilder withDateOfLastVisit(String dateOfLastVisit) {
-        this.dateOfLastVisit = new DateOfLastVisit(dateOfLastVisit);
+        this.dateOfLastVisit = Optional.of(new DateOfLastVisit(dateOfLastVisit));
+        return this;
+    }
+
+    /**
+     * Sets the {@code DateOfLastVisit} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withDateOfLastVisit() {
+        this.dateOfLastVisit = Optional.empty();
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -13,8 +13,6 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
-import javax.swing.text.html.Option;
-
 /**
  * A utility class to help with building Person objects.
  */

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -33,6 +33,7 @@ public class PersonUtil {
         StringBuilder sb = new StringBuilder();
         String personEmail = person.hasEmail() ? person.getEmail().get().value : "";
         String personAddress = person.hasAddress() ? person.getAddress().get().value : "";
+        String personDateOfLastVisit = person.hasDateOfLastVisit() ? person.getDateOfLastVisit().get().value : "";
         sb.append(PREFIX_NAME + person.getName().fullName + " ");
         sb.append(PREFIX_PHONE + person.getPhone().value + " ");
         sb.append(PREFIX_EMAIL + personEmail + " ");
@@ -40,7 +41,7 @@ public class PersonUtil {
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );
-        sb.append(PREFIX_DATEOFLASTVISIT + person.getDateOfLastVisit().value + " ");
+        sb.append(PREFIX_DATEOFLASTVISIT + personDateOfLastVisit + " ");
         return sb.toString();
     }
 
@@ -54,7 +55,7 @@ public class PersonUtil {
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.get().value).append(" "));
         descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_ADDRESS).append(address.get().value).append(" "));
         descriptor.getDateOfLastVisit().ifPresent(date ->
-                sb.append(PREFIX_DATEOFLASTVISIT).append(date.value).append(" "));
+                sb.append(PREFIX_DATEOFLASTVISIT).append(date.get().value).append(" "));
 
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();


### PR DESCRIPTION
This PR wraps the dateOfLastVisit field in Person inside an Optional.

Now to add a contact to socialbook, the date of last visit is not mandatory (i.e., users will only need to specify the name and phone number of the contact, to successfully add the contact into socialbook).

 This PR also fixed minor UI changes due to the wrapping of dateOfLastVisit inside an Optional and the display of tags.

Testcases have also been updated.

closes #114 