### PR TITLE
Add command name into user guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -166,7 +166,7 @@ Clears all entries from the address book.
 
 Format: `clear`
 
-### Populating with dummy data
+### Populating with dummy data : `seed`
 
 Adds dummy data to the address book.
 


### PR DESCRIPTION
Purely a cosmetic change for standardising the user guide

Closes #122 