### PR TITLE
Fix blank whitespace in person card when optional fields are not present

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -15,6 +15,7 @@ import seedu.address.model.person.Person;
 public class PersonCard extends UiPart<Region> {
 
     private static final String FXML = "PersonListCard.fxml";
+    public static final String EXPANDED_STYLE_CLASS = "expanded-person";
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -52,8 +53,18 @@ public class PersonCard extends UiPart<Region> {
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);
-        address.setText(person.hasAddress() ? person.getAddress().get().value : "");
-        email.setText(person.hasEmail() ? person.getEmail().get().value : "");
+        if (person.hasAddress()) {
+            address.setText(person.getAddress().get().value);
+        } else {
+            address.setText("");
+            address.setManaged(false);
+        }
+        if (person.hasEmail()) {
+            email.setText(person.getEmail().get().value);
+        } else {
+            email.setText("");
+            email.setManaged(false);
+        }
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -15,7 +15,6 @@ import seedu.address.model.person.Person;
 public class PersonCard extends UiPart<Region> {
 
     private static final String FXML = "PersonListCard.fxml";
-    public static final String EXPANDED_STYLE_CLASS = "expanded-person";
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -99,13 +99,7 @@
     -fx-padding: 0 0 0 0;
 }
 
-.list-cell:filled:even {
-    /* even list cells, 0,2,4... */
-    -fx-background-color: #c5e3f9;
-}
-
-.list-cell:filled:odd {
-    /* odd list cells, 1,3,5... */
+.list-cell:filled {
     -fx-background-color: #c5e3f9;
 }
 


### PR DESCRIPTION
This PR fixes the ugly blank whitespace that exists between a person's details, when they are not present. 
closes #117 

![no_space 1](https://github.com/user-attachments/assets/b6fcc53e-ab53-47f3-a8a1-071fcbd87d99)
