### PR TITLE
Add positive test cases for find command testing

### DIFF
--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -41,6 +41,16 @@ public class FindCommandParserTest {
         FindCommand expectedFindCommandForAddress =
                 new FindCommand(new AddressContainsKeywordsPredicate(Arrays.asList("Wall Street", "Michigan")));
         assertParseSuccess(parser, " a/Wall Street_Michigan", expectedFindCommandForAddress);
+
+        // name contains 'n/' prefix
+        FindCommand expectedFindCommandNameContainsPrefix =
+                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("n/Alice", "Bobn/")));
+        assertParseSuccess(parser, " n/n/Alice Bobn/", expectedFindCommandNameContainsPrefix);
+
+        // address contains 'a/' prefix
+        FindCommand expectedFindCommandAddressContainsPrefix =
+                new FindCommand(new AddressContainsKeywordsPredicate(Arrays.asList("Walla/ Street")));
+        assertParseSuccess(parser, " a/Walla/ Street", expectedFindCommandAddressContainsPrefix);
     }
 
 }


### PR DESCRIPTION
Add 2 positive test cases for parsing of find command. 

The first test case includes finding a person's name when the name contains the 'n/' prefix.
The second test case includes finding an address when the address contains the 'a/' prefix.

closes #160 