### PR TITLE
Update phone parsing

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -97,9 +97,9 @@ Format: `add n/NAME p/PHONE_NUMBER [e/EMAIL] [a/ADDRESS] [t/TAG]…​ [d/DATE_O
 
 Examples:
 * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 d/02-01-2024`
-* `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/12345678 t/criminal d/03-28-2024`
-* `add p/12345678 n/Jane Smith d/01-01-2024 ec/98765432`
-* `add p/12345678 n/Jane Smith d/01-01-2024`
+* `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/62345678 t/criminal d/03-28-2024`
+* `add p/92345678 n/Jane Smith d/01-01-2024 ec/98765432`
+* `add p/92345678 n/Jane Smith d/01-01-2024`
 
 ### Listing all persons : `list`
 
@@ -147,7 +147,7 @@ Finds contacts whose names or/and phone numbers or/and address contain any of th
 Format: `find [n/NAMEKEYWORDS] [p/PHONEKEYWORDS] [a/ADDRESSKEYWORDS]`
 
 **NOTE:** At least one field MUST be provided  
-  e.g. `find n/Hans` or `find p/12345678` or `find a/wall street` will work  
+  e.g. `find n/Hans` or `find p/82345678` or `find a/wall street` will work  
   e.g. `find Hans` or `find wall street` or `find` will fail
 * The search is case-insensitive. e.g `hans` will match `Hans` or `wall Street` will match `Wall Street`
 * The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
@@ -244,6 +244,15 @@ _Details coming soon ..._
 
 --------------------------------------------------------------------------------------------------------------------
 
+## Contact field requirements
+
+### Phone
+* Phone numbers can only contain 8 numbers, and must begin with a 6, 8, or 9.
+* Spaces in the middle of a phone number are accepted (eg. 9123 4523), as are phone numbers without spaces (eg. 91234523). 
+* Spaces in unusual locations will render the phone number invalid (eg. 912 34523).
+
+--------------------------------------------------------------------------------------------------------------------
+
 ## FAQ
 
 **Q**: How do I transfer my data to another Computer?<br>
@@ -262,7 +271,7 @@ _Details coming soon ..._
 
 Action     | Format, Examples
 -----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-**Add**    | `add n/NAME p/PHONE_NUMBER [e/EMAIL] [a/ADDRESS] [t/TAG]…​ [d/DATE_OF_LAST_VISIT] [ec/EMERGENCY_CONTACT]` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague d/07-23-2024`
+**Add**    | `add n/NAME p/PHONE_NUMBER [e/EMAIL] [a/ADDRESS] [t/TAG]…​ [d/DATE_OF_LAST_VISIT] [ec/EMERGENCY_CONTACT]` <br> e.g., `add n/James Ho p/82224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague d/07-23-2024`
 **Clear**  | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
 **Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​ [d/DATE_OF_LAST_VISIT]`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -20,7 +20,7 @@ public class Phone {
      * After the first character, there must be 3 more numbers,
      * followed by any number of whitespaces before 4 more numbers.
      * This comes out to 8 numbers in total, with any number of whitespaces separating the phone
-     * number into 2 halves of 4 numbers each. Some software parses phone numbers
+     * number into 2 halves of 4 numbers each. Some software displays phone numbers
      * this way, so we want to support parsing of this phone number format too.
      */
     public static final String VALIDATION_REGEX = "[689]\\d{3}\\s*\\d{4}";

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -9,9 +9,20 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Phone {
 
-
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers must have exactly 8 numbers, and no letters or symbols.";
+            "Phone numbers must have exactly 8 numbers, and no letters or symbols. \n"
+            + "They can only begin with 6, 8, or 9.";
+
+    /**
+     * This validation regex checks that the first character in the phone number is either a 6, 8, or 9.
+     * Since {@code SocialBook} is meant only for use in Singapore, restricting it to the
+     * possible phone numbers helps users catch possible typos.
+     * After the first character, there must be 3 more numbers,
+     * followed by any number of whitespaces before 4 more numbers.
+     * This comes out to 8 numbers in total, with any number of whitespaces separating the phone
+     * number into 2 halves of 4 numbers each. Some software parses phone numbers
+     * this way, so we want to support parsing of this phone number format too.
+     */
     public static final String VALIDATION_REGEX = "[689]\\d{3}\\s*\\d{4}";
     public final String value;
 

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -11,8 +11,8 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be exactly 8 digits long.";
-    public static final String VALIDATION_REGEX = "\\d{8}";
+            "Phone numbers must have exactly 8 numbers, and no letters or symbols.";
+    public static final String VALIDATION_REGEX = "[689]\\d{3}\\s*\\d{4}";
     public final String value;
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -30,8 +30,8 @@ public class CommandTestUtil {
 
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo-Choo";
-    public static final String VALID_PHONE_AMY = "11111111";
-    public static final String VALID_PHONE_BOB = "22222222";
+    public static final String VALID_PHONE_AMY = "8888\t8888";
+    public static final String VALID_PHONE_BOB = "69281029";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_EMERGENCY_CONTACT_AMY = VALID_PHONE_AMY;
@@ -66,7 +66,7 @@ public class CommandTestUtil {
 
     // whitespace-only names are invalid
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "     ";
-    // 'a' not allowed in phones, emergency contacts
+    // 'a' not allowed in phones or emergency contacts
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a";
     public static final String INVALID_EMERGENCY_CONTACT_DESC = " " + PREFIX_EMERGENCY_CONTACT + "911a";
     // missing '@' symbol

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -35,10 +35,10 @@ public class ParserUtilTest {
     private static final String INVALID_DATEOFLASTVISIT = "13/13/2024";
 
     private static final String VALID_NAME = "Rachel Walker-Runner";
-    private static final String VALID_PHONE = "12345678";
+    private static final String VALID_PHONE = "92345678";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
-    private static final String VALID_EMERGENCY_CONTACT = "12345678";
+    private static final String VALID_EMERGENCY_CONTACT = "62345678";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
     private static final String VALID_DATEOFLASTVISIT = "02-02-2024";

--- a/src/test/java/seedu/address/model/person/AddressContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/AddressContainsKeywordsPredicateTest.java
@@ -71,7 +71,7 @@ public class AddressContainsKeywordsPredicateTest {
 
         // Keywords match name, email and phone, but does not match address
         predicate = new AddressContainsKeywordsPredicate(Arrays.asList("Alice", "alice@email.com", "1234"));
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345678")
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("92345678")
                 .withEmail("alice@email.com").withAddress("Main Street").build()));
     }
 

--- a/src/test/java/seedu/address/model/person/EmergencyContactTest.java
+++ b/src/test/java/seedu/address/model/person/EmergencyContactTest.java
@@ -26,12 +26,12 @@ public class EmergencyContactTest {
 
         // invalid emergency contacts
         assertFalse(EmergencyContact.isValidEmergencyContact("")); // empty string
-        assertFalse(EmergencyContact.isValidEmergencyContact(" ")); // spaces only
+        assertFalse(EmergencyContact.isValidEmergencyContact("   \t\n  ")); // whitespaces only
         assertFalse(EmergencyContact.isValidEmergencyContact("phone")); // non-numeric
         assertFalse(EmergencyContact.isValidEmergencyContact("9011p041")); // alphabets within digits
-        assertFalse(EmergencyContact.isValidEmergencyContact("1234")); // less than 8 digits
-        assertFalse(EmergencyContact.isValidEmergencyContact("123456789")); // more than 8 digits
-        assertFalse(EmergencyContact.isValidEmergencyContact("12345 678")); // whitespace in weird place
+        assertFalse(EmergencyContact.isValidEmergencyContact("9234")); // less than 8 digits
+        assertFalse(EmergencyContact.isValidEmergencyContact("623456789")); // more than 8 digits
+        assertFalse(EmergencyContact.isValidEmergencyContact("82345 678")); // whitespace in weird place
         assertFalse(EmergencyContact.isValidEmergencyContact("00000000")); // does not start with 6, 8, or 9
         assertFalse(EmergencyContact.isValidEmergencyContact("7918 2933")); // does not start with 6, 8, or 9
 

--- a/src/test/java/seedu/address/model/person/EmergencyContactTest.java
+++ b/src/test/java/seedu/address/model/person/EmergencyContactTest.java
@@ -29,14 +29,18 @@ public class EmergencyContactTest {
         assertFalse(EmergencyContact.isValidEmergencyContact(" ")); // spaces only
         assertFalse(EmergencyContact.isValidEmergencyContact("phone")); // non-numeric
         assertFalse(EmergencyContact.isValidEmergencyContact("9011p041")); // alphabets within digits
-        assertFalse(EmergencyContact.isValidEmergencyContact("9312 1534")); // spaces within digits
-        assertFalse(EmergencyContact.isValidEmergencyContact("1234")); // not 8 digits long
-        assertFalse(EmergencyContact.isValidEmergencyContact("123456789")); // not 8 digits long
+        assertFalse(EmergencyContact.isValidEmergencyContact("1234")); // less than 8 digits
+        assertFalse(EmergencyContact.isValidEmergencyContact("123456789")); // more than 8 digits
+        assertFalse(EmergencyContact.isValidEmergencyContact("12345 678")); // whitespace in weird place
+        assertFalse(EmergencyContact.isValidEmergencyContact("00000000")); // does not start with 6, 8, or 9
+        assertFalse(EmergencyContact.isValidEmergencyContact("7918 2933")); // does not start with 6, 8, or 9
 
         // valid emergency contacts
-        assertTrue(EmergencyContact.isValidEmergencyContact("00000000")); // exactly 8 zeros
         assertTrue(EmergencyContact.isValidEmergencyContact("93121534")); // normal-looking mobile number
         assertTrue(EmergencyContact.isValidEmergencyContact("62429384")); // normal-looking landline number
+        assertTrue(EmergencyContact.isValidEmergencyContact("9312 1534")); // spaces within digits
+        assertTrue(EmergencyContact.isValidEmergencyContact("8234   3234")); // multiple spaces within number
+        assertTrue(EmergencyContact.isValidEmergencyContact("9992\t2933")); // tab within number
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -70,7 +70,7 @@ public class NameContainsKeywordsPredicateTest {
 
         // Keywords match phone, email and address, but does not match name
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345678")
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("92345678")
                 .withEmail("alice@email.com").withAddress("Main Street").build()));
     }
 

--- a/src/test/java/seedu/address/model/person/PhoneContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneContainsKeywordsPredicateTest.java
@@ -44,31 +44,31 @@ public class PhoneContainsKeywordsPredicateTest {
     public void test_phoneContainsKeywords_returnsTrue() {
         // One keyword
         PhoneContainsKeywordsPredicate predicate =
-                new PhoneContainsKeywordsPredicate(Collections.singletonList("12345678"));
-        assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+                new PhoneContainsKeywordsPredicate(Collections.singletonList("92345678"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("92345678").build()));
 
         // Multiple keywords
-        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("1234", "5678"));
-        assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("9234", "5678"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("92345678").build()));
 
         // Only one matching keyword
-        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("1234", "5678"));
-        assertTrue(predicate.test(new PersonBuilder().withPhone("12349876").build()));
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("9234", "5678"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("92349876").build()));
     }
 
     @Test
     public void test_phoneDoesNotContainKeywords_returnsFalse() {
         // Zero keywords
         PhoneContainsKeywordsPredicate predicate = new PhoneContainsKeywordsPredicate(Collections.emptyList());
-        assertFalse(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+        assertFalse(predicate.test(new PersonBuilder().withPhone("82345678").build()));
 
         // Non-matching keyword
         predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("7899"));
-        assertFalse(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+        assertFalse(predicate.test(new PersonBuilder().withPhone("82345678").build()));
 
         // Keywords match name, email and address, but does not match phone
         predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("Alice", "alice@email.com", "Main", "Street"));
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345678")
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("82345678")
                 .withEmail("alice@email.com").withAddress("Main Street").build()));
     }
 

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -30,14 +30,19 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("91")); // not 8 digits long
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
-        assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
-        assertFalse(Phone.isValidPhone("1234")); // not 8 digits long
-        assertFalse(Phone.isValidPhone("123456789")); // not 8 digits long
+        assertFalse(Phone.isValidPhone("1234")); // less than 8 digits
+        assertFalse(Phone.isValidPhone("123456789")); // more than 8 digits
+        assertFalse(Phone.isValidPhone("12345 678")); // whitespace not separating phone number into halves
+        assertFalse(Phone.isValidPhone("00000000")); // does not start with 6, 8, or 9
+        assertFalse(Phone.isValidPhone("7918 2933")); // does not start with 6, 8, or 9
 
         // valid phone numbers
-        assertTrue(Phone.isValidPhone("00000000")); // exactly 8 zeros
         assertTrue(Phone.isValidPhone("93121534")); // normal-looking mobile number
         assertTrue(Phone.isValidPhone("62429384")); // normal-looking landline number
+        assertTrue(Phone.isValidPhone("9312 1534")); // one space between digits
+        assertTrue(Phone.isValidPhone("9001     2003")); // multiple spaces between digits
+        assertTrue(Phone.isValidPhone("9123\t4567")); // tab between digits
+
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -26,13 +26,12 @@ public class PhoneTest {
 
         // invalid phone numbers
         assertFalse(Phone.isValidPhone("")); // empty string
-        assertFalse(Phone.isValidPhone(" ")); // spaces only
-        assertFalse(Phone.isValidPhone("91")); // not 8 digits long
+        assertFalse(Phone.isValidPhone("   \t\n  ")); // whitespaces only
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
-        assertFalse(Phone.isValidPhone("1234")); // less than 8 digits
-        assertFalse(Phone.isValidPhone("123456789")); // more than 8 digits
-        assertFalse(Phone.isValidPhone("12345 678")); // whitespace not separating phone number into halves
+        assertFalse(Phone.isValidPhone("9234")); // less than 8 digits
+        assertFalse(Phone.isValidPhone("623456789")); // more than 8 digits
+        assertFalse(Phone.isValidPhone("82345 678")); // whitespace not separating phone number into halves
         assertFalse(Phone.isValidPhone("00000000")); // does not start with 6, 8, or 9
         assertFalse(Phone.isValidPhone("7918 2933")); // does not start with 6, 8, or 9
 
@@ -42,7 +41,6 @@ public class PhoneTest {
         assertTrue(Phone.isValidPhone("9312 1534")); // one space between digits
         assertTrue(Phone.isValidPhone("9001     2003")); // multiple spaces between digits
         assertTrue(Phone.isValidPhone("9123\t4567")); // tab between digits
-
     }
 
     @Test


### PR DESCRIPTION
This PR does two things simultaneously.

First, it allows phone numbers to have whitespace in the middle between 2 groups of 4 numbers.
This is in line with how we had originally envisioned the way that phone numbers should be parsed, and it also makes sense from a human readability point of view. However, spaces in unexpected places will not be allowed.
Thus, `9112 3942`, `91123942`, and even `9112        3942` are allowed, but `911 23942` will not be allowed.
Closes #149 

Secondly, it requires the first digit of the phone number to be a 6, 8, or 9. This is because we have scoped SocialBook to be for social workers in Singapore, and so any "phone number" entered by users that does not begin with those numbers must be a typo, so we want the error to notify them of it.
Closes #168 

Tests have been updated accordingly, as has the user guide. For further clarification on the multiple fields we are adding, I have also created a new section in the user guide **Contact field requirements**, where we can specify the detailed requirements on any contact fields that aren't obvious. This might be related to the intention of #153, but I'm not sure if this is what the suggestion meant, so do let me know if this would be fine.