### PR TITLE
Add undocumented behaviour into javadoc comment

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -139,6 +139,7 @@ public class MainWindow extends UiPart<Stage> {
 
     /**
      * Updates the displayed person list for the user.
+     * Will only be called if {@code indexToView} is not empty.
      */
     @FXML
     public void handleView(Optional<Index> indexToView) {


### PR DESCRIPTION
Very minor fix that I just remembered! Prevents assertion error from being a surprise for devs