### PR TITLE
Update Viewing to match person for sorting

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -4,28 +4,14 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Objects;
-import java.util.Optional;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
  * Represents the result of a command execution.
  */
 public class CommandResult {
-    /**
-     * Represents the lack of an index returned in a {@code CommandResult}.
-     * Declared as public so that {@code HelpCommand} and {@code ExitCommand} are able to use it.
-     */
-    public static final Index NO_INDEX_TO_VIEW = null;
-
     private final String feedbackToUser;
-
-    /**
-     * User wants to view all information about a particular contact.
-     * May or may not hold an {@code Index}, depending on whether the user has requested to view a contact.
-     */
-    private final Optional<Index> indexToView;
 
     /** Help information should be shown to the user. */
     private final boolean showHelp;
@@ -36,10 +22,9 @@ public class CommandResult {
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, Index indexToView, boolean showHelp, boolean shouldExit) {
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean shouldExit) {
         requireAllNonNull(feedbackToUser, showHelp, shouldExit);
         this.feedbackToUser = requireNonNull(feedbackToUser);
-        this.indexToView = Optional.ofNullable(indexToView);
         this.showHelp = showHelp;
         this.shouldExit = shouldExit;
     }
@@ -49,19 +34,11 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, NO_INDEX_TO_VIEW, false, false);
+        this(feedbackToUser, false, false);
     }
 
     public String getFeedbackToUser() {
         return feedbackToUser;
-    }
-
-    public Optional<Index> getIndexToView() {
-        return indexToView;
-    }
-
-    public boolean isViewCommand() {
-        return indexToView.isPresent();
     }
 
     public boolean isShowHelp() {
@@ -85,21 +62,19 @@ public class CommandResult {
 
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
-                && indexToView.equals(otherCommandResult.indexToView)
                 && showHelp == otherCommandResult.showHelp
                 && shouldExit == otherCommandResult.shouldExit;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, indexToView, showHelp, shouldExit);
+        return Objects.hash(feedbackToUser, showHelp, shouldExit);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .add("feedbackToUser", feedbackToUser)
-                .add("indexToView", indexToView)
                 .add("showHelp", showHelp)
                 .add("shouldExit", shouldExit)
                 .toString();

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -113,7 +113,7 @@ public class EditCommand extends Command {
         Optional<EmergencyContact> updatedEmergencyContact = editPersonDescriptor.getEmergencyContact()
                 .orElse(personToEdit.getEmergencyContact());
         Remark updatedRemark = editPersonDescriptor.getRemark().orElse(personToEdit.getRemark());
-        boolean isBeingViewed = personToEdit.isBeingViewed();
+        boolean isBeingViewed = personToEdit.hasFullViewToggled();
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress,
                 updatedTags, updatedDateOfLastVisit, updatedEmergencyContact, updatedRemark, isBeingViewed);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -113,9 +113,10 @@ public class EditCommand extends Command {
         Optional<EmergencyContact> updatedEmergencyContact = editPersonDescriptor.getEmergencyContact()
                 .orElse(personToEdit.getEmergencyContact());
         Remark updatedRemark = editPersonDescriptor.getRemark().orElse(personToEdit.getRemark());
+        boolean isBeingViewed = personToEdit.hasFullViewToggled();
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress,
-                updatedTags, updatedDateOfLastVisit, updatedEmergencyContact, updatedRemark);
+                updatedTags, updatedDateOfLastVisit, updatedEmergencyContact, updatedRemark, isBeingViewed);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -113,7 +113,7 @@ public class EditCommand extends Command {
         Optional<EmergencyContact> updatedEmergencyContact = editPersonDescriptor.getEmergencyContact()
                 .orElse(personToEdit.getEmergencyContact());
         Remark updatedRemark = editPersonDescriptor.getRemark().orElse(personToEdit.getRemark());
-        boolean isBeingViewed = personToEdit.hasFullViewToggled();
+        boolean isBeingViewed = personToEdit.isBeingViewed();
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress,
                 updatedTags, updatedDateOfLastVisit, updatedEmergencyContact, updatedRemark, isBeingViewed);

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -13,7 +13,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, CommandResult.NO_INDEX_TO_VIEW, false, true);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -16,6 +16,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, CommandResult.NO_INDEX_TO_VIEW, true, false);
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -54,7 +54,7 @@ public class ViewCommand extends Command {
         }
 
         Person personToView = lastShownList.get(index.getZeroBased());
-        personToView.toggleView();
+        model.setPerson(personToView, personToView.getToggledViewPerson());
         String commandResultMessage = String.format(MESSAGE_VIEW_SUCCESS, Messages.format(personToView));
 
         return new CommandResult(commandResultMessage, false, false);

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -54,9 +54,10 @@ public class ViewCommand extends Command {
         }
 
         Person personToView = lastShownList.get(index.getZeroBased());
+        personToView.toggleView();
         String commandResultMessage = String.format(MESSAGE_VIEW_SUCCESS, Messages.format(personToView));
 
-        return new CommandResult(commandResultMessage, index, false, false);
+        return new CommandResult(commandResultMessage, false, false);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -109,7 +109,6 @@ public class ModelManager implements Model {
     @Override
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
-
         addressBook.setPerson(target, editedPerson);
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -28,7 +28,7 @@ public class Person {
     private final Optional<DateOfLastVisit> dateOfLastVisit;
     private final Optional<EmergencyContact> emergencyContact;
     private final Remark remark;
-    private final boolean hasFullViewToggled;
+    private final boolean isBeingViewed;
 
     /**
      * Every field must be present and not null.
@@ -45,7 +45,7 @@ public class Person {
         this.dateOfLastVisit = dateOfLastVisit;
         this.emergencyContact = emergencyContact;
         this.remark = remark;
-        this.hasFullViewToggled = false;
+        this.isBeingViewed = false;
     }
 
     /**
@@ -53,7 +53,7 @@ public class Person {
      */
     public Person(Name name, Phone phone, Optional<Email> email, Optional<Address> address, Set<Tag> tags,
                   Optional<DateOfLastVisit> dateOfLastVisit, Optional<EmergencyContact> emergencyContact,
-                  Remark remark, boolean hasFullViewToggled) {
+                  Remark remark, boolean isBeingViewed) {
         requireAllNonNull(name, phone, email, address, tags, dateOfLastVisit, remark);
         this.name = name;
         this.phone = phone;
@@ -63,7 +63,7 @@ public class Person {
         this.dateOfLastVisit = dateOfLastVisit;
         this.emergencyContact = emergencyContact;
         this.remark = remark;
-        this.hasFullViewToggled = hasFullViewToggled;
+        this.isBeingViewed = isBeingViewed;
     }
 
     /**
@@ -78,7 +78,7 @@ public class Person {
         this.dateOfLastVisit = toHaveViewToggled.dateOfLastVisit;
         this.emergencyContact = toHaveViewToggled.emergencyContact;
         this.remark = toHaveViewToggled.remark;
-        this.hasFullViewToggled = !toHaveViewToggled.hasFullViewToggled();
+        this.isBeingViewed = !toHaveViewToggled.isBeingViewed();
     }
 
     public Name getName() {
@@ -169,8 +169,8 @@ public class Person {
     /**
      * Returns whether the detailed view of Person is toggled.
      */
-    public boolean hasFullViewToggled() {
-        return hasFullViewToggled;
+    public boolean isBeingViewed() {
+        return isBeingViewed;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -28,7 +28,7 @@ public class Person {
     private final Optional<DateOfLastVisit> dateOfLastVisit;
     private final Optional<EmergencyContact> emergencyContact;
     private final Remark remark;
-    private final boolean isBeingViewed;
+    private final boolean hasFullViewToggled;
 
     /**
      * Every field must be present and not null.
@@ -45,7 +45,7 @@ public class Person {
         this.dateOfLastVisit = dateOfLastVisit;
         this.emergencyContact = emergencyContact;
         this.remark = remark;
-        this.isBeingViewed = false;
+        this.hasFullViewToggled = false;
     }
 
     /**
@@ -53,7 +53,7 @@ public class Person {
      */
     public Person(Name name, Phone phone, Optional<Email> email, Optional<Address> address, Set<Tag> tags,
                   Optional<DateOfLastVisit> dateOfLastVisit, Optional<EmergencyContact> emergencyContact,
-                  Remark remark, boolean isBeingViewed) {
+                  Remark remark, boolean hasFullViewToggled) {
         requireAllNonNull(name, phone, email, address, tags, dateOfLastVisit, remark);
         this.name = name;
         this.phone = phone;
@@ -63,22 +63,22 @@ public class Person {
         this.dateOfLastVisit = dateOfLastVisit;
         this.emergencyContact = emergencyContact;
         this.remark = remark;
-        this.isBeingViewed = isBeingViewed;
+        this.hasFullViewToggled = hasFullViewToggled;
     }
 
     /**
      * Constructs an identical Person with view toggled.
      */
-    private Person(Person toHaveViewToggled) {
-        this.name = toHaveViewToggled.name;
-        this.phone = toHaveViewToggled.phone;
-        this.email = toHaveViewToggled.email;
-        this.address = toHaveViewToggled.address;
-        this.tags.addAll(toHaveViewToggled.tags);
-        this.dateOfLastVisit = toHaveViewToggled.dateOfLastVisit;
-        this.emergencyContact = toHaveViewToggled.emergencyContact;
-        this.remark = toHaveViewToggled.remark;
-        this.isBeingViewed = !toHaveViewToggled.isBeingViewed();
+    private Person(Person personToView) {
+        this.name = personToView.name;
+        this.phone = personToView.phone;
+        this.email = personToView.email;
+        this.address = personToView.address;
+        this.tags.addAll(personToView.tags);
+        this.dateOfLastVisit = personToView.dateOfLastVisit;
+        this.emergencyContact = personToView.emergencyContact;
+        this.remark = personToView.remark;
+        this.hasFullViewToggled = !personToView.hasFullViewToggled();
     }
 
     public Name getName() {
@@ -169,8 +169,8 @@ public class Person {
     /**
      * Returns whether the detailed view of Person is toggled.
      */
-    public boolean isBeingViewed() {
-        return isBeingViewed;
+    public boolean hasFullViewToggled() {
+        return hasFullViewToggled;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -28,7 +28,7 @@ public class Person {
     private final Optional<DateOfLastVisit> dateOfLastVisit;
     private final Optional<EmergencyContact> emergencyContact;
     private final Remark remark;
-    private boolean hasFullViewToggled;
+    private final boolean hasFullViewToggled;
 
     /**
      * Every field must be present and not null.
@@ -64,6 +64,21 @@ public class Person {
         this.emergencyContact = emergencyContact;
         this.remark = remark;
         this.hasFullViewToggled = hasFullViewToggled;
+    }
+
+    /**
+     * Constructs an identical Person with view toggled.
+     */
+    private Person(Person toHaveViewToggled) {
+        this.name = toHaveViewToggled.name;
+        this.phone = toHaveViewToggled.phone;
+        this.email = toHaveViewToggled.email;
+        this.address = toHaveViewToggled.address;
+        this.tags.addAll(toHaveViewToggled.tags);
+        this.dateOfLastVisit = toHaveViewToggled.dateOfLastVisit;
+        this.emergencyContact = toHaveViewToggled.emergencyContact;
+        this.remark = toHaveViewToggled.remark;
+        this.hasFullViewToggled = !toHaveViewToggled.hasFullViewToggled();
     }
 
     public Name getName() {
@@ -161,8 +176,8 @@ public class Person {
     /**
      * Toggles the view of the person.
      */
-    public void toggleView() {
-        this.hasFullViewToggled = !hasFullViewToggled;
+    public Person getToggledViewPerson() {
+        return new Person(this);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -28,6 +28,7 @@ public class Person {
     private final Optional<DateOfLastVisit> dateOfLastVisit;
     private final Optional<EmergencyContact> emergencyContact;
     private final Remark remark;
+    private boolean hasFullViewToggled;
 
     /**
      * Every field must be present and not null.
@@ -44,6 +45,25 @@ public class Person {
         this.dateOfLastVisit = dateOfLastVisit;
         this.emergencyContact = emergencyContact;
         this.remark = remark;
+        this.hasFullViewToggled = false;
+    }
+
+    /**
+     * Constructor for creating an edited person.
+     */
+    public Person(Name name, Phone phone, Optional<Email> email, Optional<Address> address, Set<Tag> tags,
+                  Optional<DateOfLastVisit> dateOfLastVisit, Optional<EmergencyContact> emergencyContact,
+                  Remark remark, boolean hasFullViewToggled) {
+        requireAllNonNull(name, phone, email, address, tags, dateOfLastVisit, remark);
+        this.name = name;
+        this.phone = phone;
+        this.email = email;
+        this.address = address;
+        this.tags.addAll(tags);
+        this.dateOfLastVisit = dateOfLastVisit;
+        this.emergencyContact = emergencyContact;
+        this.remark = remark;
+        this.hasFullViewToggled = hasFullViewToggled;
     }
 
     public Name getName() {
@@ -129,6 +149,20 @@ public class Person {
 
     public Optional<EmergencyContact> getEmergencyContact() {
         return emergencyContact;
+    }
+
+    /**
+     * Returns whether the detailed view of Person is toggled.
+     */
+    public boolean hasFullViewToggled() {
+        return hasFullViewToggled;
+    }
+
+    /**
+     * Toggles the view of the person.
+     */
+    public void toggleView() {
+        this.hasFullViewToggled = !hasFullViewToggled;
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -1,6 +1,5 @@
 package seedu.address.ui;
 
-import java.util.Optional;
 import java.util.logging.Logger;
 
 import javafx.event.ActionEvent;
@@ -13,7 +12,6 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -138,19 +136,6 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * Updates the displayed person list for the user.
-     * Will only be called if {@code indexToView} is not empty.
-     */
-    @FXML
-    public void handleView(Optional<Index> indexToView) {
-        assert indexToView.isPresent() : "This method should not be called if indexToView is empty";
-
-        personListPanelPlaceholder.getChildren().clear();
-        personListPanel.updateViewedPersons(indexToView);
-        personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
-    }
-
-    /**
      * Opens the help window or focuses on it if it's already opened.
      */
     @FXML
@@ -192,10 +177,6 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setSuccessFeedbackToUser(commandResult.getFeedbackToUser());
-
-            if (commandResult.isViewCommand()) {
-                handleView(commandResult.getIndexToView());
-            }
 
             if (commandResult.isShowHelp()) {
                 handleHelp();

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -45,7 +45,7 @@ public class PersonListPanel extends UiPart<Region> {
             if (empty || person == null) {
                 setGraphic(null);
                 setText(null);
-            } else if (person.hasFullViewToggled()) {
+            } else if (person.isBeingViewed()) {
                 // if the user had requested this person to be viewed in full, return a PersonCardFull instead
                 setGraphic(new PersonCardFull(person, getIndex() + DISPLAYED_INDEX_OFFSET).getRoot());
             } else {

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -45,7 +45,7 @@ public class PersonListPanel extends UiPart<Region> {
             if (empty || person == null) {
                 setGraphic(null);
                 setText(null);
-            } else if (person.isBeingViewed()) {
+            } else if (person.hasFullViewToggled()) {
                 // if the user had requested this person to be viewed in full, return a PersonCardFull instead
                 setGraphic(new PersonCardFull(person, getIndex() + DISPLAYED_INDEX_OFFSET).getRoot());
             } else {

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -1,8 +1,5 @@
 package seedu.address.ui;
 
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -11,7 +8,6 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.commons.core.index.Index;
 import seedu.address.model.person.Person;
 
 /**
@@ -23,9 +19,6 @@ public class PersonListPanel extends UiPart<Region> {
 
     private final Logger logger = LogsCenter.getLogger(PersonListPanel.class);
 
-    /** Tracks all the persons that the user has requested to view all the information on. */
-    private final Set<Integer> personsBeingViewed;
-
     @FXML
     private ListView<Person> personListView;
 
@@ -34,26 +27,8 @@ public class PersonListPanel extends UiPart<Region> {
      */
     public PersonListPanel(ObservableList<Person> personList) {
         super(FXML);
-        personsBeingViewed = new HashSet<>();
         personListView.setItems(personList);
         // cell factory creates new ListCell objects for each item in the ListView.
-        personListView.setCellFactory(listView -> new PersonListViewCell());
-    }
-
-    /**
-     * Remakes the {@code ListView<Person> personListView} such that contact cards
-     * that the user has requested to view are expanded {@code PersonCardFull}.
-     *
-     * @param indexToToggle The index that the user wishes to toggle the view status on.
-     */
-    public void updateViewedPersons(Optional<Index> indexToToggle) {
-        assert indexToToggle.isPresent() : "Index should not be empty at this point";
-        int index = indexToToggle.get().getZeroBased();
-        if (personsBeingViewed.contains(index)) {
-            personsBeingViewed.remove(index);
-        } else {
-            personsBeingViewed.add(index);
-        }
         personListView.setCellFactory(listView -> new PersonListViewCell());
     }
 
@@ -70,7 +45,7 @@ public class PersonListPanel extends UiPart<Region> {
             if (empty || person == null) {
                 setGraphic(null);
                 setText(null);
-            } else if (personsBeingViewed.contains(currCellIndexInt)) {
+            } else if (person.hasFullViewToggled()) {
                 // if the user had requested this person to be viewed in full, return a PersonCardFull instead
                 setGraphic(new PersonCardFull(person, getIndex() + DISPLAYED_INDEX_OFFSET).getRoot());
             } else {

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -4,8 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
 import org.junit.jupiter.api.Test;
 
@@ -13,13 +11,13 @@ public class CommandResultTest {
     private static final CommandResult NORMAL_COMMAND_RESULT = new CommandResult("normal feedback");
 
     private static final CommandResult VIEW_COMMAND_RESULT = new CommandResult("view feedback",
-            INDEX_SECOND_PERSON, false, false);
+            false, false);
 
     private static final CommandResult HELP_COMMAND_RESULT = new CommandResult("help feedback",
-            CommandResult.NO_INDEX_TO_VIEW, true, false);
+            true, false);
 
     private static final CommandResult EXIT_COMMAND_RESULT = new CommandResult("exit feedback",
-            CommandResult.NO_INDEX_TO_VIEW, false, true);
+            false, true);
 
     @Test
     public void equals() {
@@ -27,7 +25,7 @@ public class CommandResultTest {
         // same values -> returns true
         assertTrue(NORMAL_COMMAND_RESULT.equals(new CommandResult("normal feedback")));
         assertTrue(NORMAL_COMMAND_RESULT.equals(new CommandResult("normal feedback",
-                CommandResult.NO_INDEX_TO_VIEW, false, false)));
+                false, false)));
 
         // same object -> returns true
         assertTrue(NORMAL_COMMAND_RESULT.equals(NORMAL_COMMAND_RESULT));
@@ -41,25 +39,13 @@ public class CommandResultTest {
         // different feedbackToUser value -> returns false
         assertFalse(NORMAL_COMMAND_RESULT.equals(new CommandResult("different feedback")));
 
-        // different indexToView value -> returns false
-        assertFalse(NORMAL_COMMAND_RESULT.equals(new CommandResult("normal feedback",
-                INDEX_FIRST_PERSON, false, false)));
-
         // different showHelp value -> returns false
         assertFalse(NORMAL_COMMAND_RESULT.equals(new CommandResult("normal feedback",
-                CommandResult.NO_INDEX_TO_VIEW, true, false)));
+                true, false)));
 
         // different exit value -> returns false
         assertFalse(NORMAL_COMMAND_RESULT.equals(new CommandResult("normal feedback",
-                CommandResult.NO_INDEX_TO_VIEW, false, true)));
-    }
-
-    @Test
-    public void isViewCommand() {
-        assertFalse(NORMAL_COMMAND_RESULT.isViewCommand());
-        assertTrue(VIEW_COMMAND_RESULT.isViewCommand());
-        assertFalse(HELP_COMMAND_RESULT.isViewCommand());
-        assertFalse(EXIT_COMMAND_RESULT.isViewCommand());
+                false, true)));
     }
 
     @Test
@@ -86,24 +72,19 @@ public class CommandResultTest {
         // different feedbackToUser value -> returns different hashcode
         assertNotEquals(NORMAL_COMMAND_RESULT.hashCode(), new CommandResult("different").hashCode());
 
-        // different indexToView value -> returns different hashcode
-        assertNotEquals(NORMAL_COMMAND_RESULT.hashCode(), new CommandResult("normal feedback",
-                INDEX_FIRST_PERSON, false, false).hashCode());
-
         // different showHelp value -> returns different hashcode
         assertNotEquals(NORMAL_COMMAND_RESULT.hashCode(), new CommandResult("normal feedback",
-                CommandResult.NO_INDEX_TO_VIEW, true, false).hashCode());
+                true, false).hashCode());
 
         // different exit value -> returns different hashcode
         assertNotEquals(NORMAL_COMMAND_RESULT.hashCode(), new CommandResult("normal feedback",
-                CommandResult.NO_INDEX_TO_VIEW, false, true).hashCode());
+                false, true).hashCode());
     }
 
     @Test
     public void toStringMethod() {
         String expected = CommandResult.class.getCanonicalName()
                 + "{feedbackToUser=" + NORMAL_COMMAND_RESULT.getFeedbackToUser()
-                + ", indexToView=" + NORMAL_COMMAND_RESULT.getIndexToView()
                 + ", showHelp=" + NORMAL_COMMAND_RESULT.isShowHelp()
                 + ", shouldExit=" + NORMAL_COMMAND_RESULT.isExit() + "}";
         assertEquals(expected, NORMAL_COMMAND_RESULT.toString());

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -15,7 +15,7 @@ public class ExitCommandTest {
     @Test
     public void execute_exit_success() {
         CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT,
-                CommandResult.NO_INDEX_TO_VIEW, false, true);
+                false, true);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -15,7 +15,7 @@ public class HelpCommandTest {
     @Test
     public void execute_help_success() {
         CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE,
-                CommandResult.NO_INDEX_TO_VIEW, true, false);
+                true, false);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -33,7 +33,7 @@ public class ViewCommandTest {
         ViewCommand viewCommand = new ViewCommand(INDEX_FIRST_PERSON);
         String expectedMessage = String.format(ViewCommand.MESSAGE_VIEW_SUCCESS, Messages.format(personToView));
         CommandResult expectedCommandResult = new CommandResult(expectedMessage,
-                INDEX_FIRST_PERSON, false, false);
+                false, false);
 
         assertCommandSuccess(viewCommand, model, expectedCommandResult, model);
     }


### PR DESCRIPTION
Add a boolean attached to a person to indicate they are being viewed. The view command now toggles this boolean instead of interacting with the UI directly. The UI checks the person's status when updating the person. 

Closes #179 

